### PR TITLE
DIT-754 Changes for Google Tag Manager

### DIFF
--- a/app/assets/javascripts/ga-tag-manager.js
+++ b/app/assets/javascripts/ga-tag-manager.js
@@ -1,0 +1,8 @@
+(function(w,d,s,l,i){
+    w[l]=w[l]||[];
+    w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});
+    var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';
+    j.async=true;
+    j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;
+    f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-TSFTCWZ');

--- a/app/views/govuk_wrapper.scala.html
+++ b/app/views/govuk_wrapper.scala.html
@@ -34,17 +34,11 @@
       headScripts = None)
     <meta name="format-detection" content="telephone=no" />
     <link rel="stylesheet" href='@routes.Assets.versioned("stylesheets/bindingtarifftraderfrontend-app.css")' />
-    <script type="text/javascript">
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-                m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-
-        ga('create', '@appConfig.analyticsToken', 'service.gov.uk');
-        ga('set', 'page', location.pathname);
-        ga('send', 'pageview', { 'anonymizeIp': true });
-    </script>
+    <noscript>
+        <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-TSFTCWZ"
+        height="0" width="0" style="display:none;visibility:hidden"></iframe>
+    </noscript>
+    <script type="text/javascript" src=@routes.Assets.versioned("javascript/ga-tag-manager.js")></script>
 }
 
 @insideHeader = {

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -57,7 +57,7 @@ play.application.loader = "uk.gov.hmrc.play.bootstrap.ApplicationLoader"
 # Play filters
 # ~~~~
 play.http.filters = "filters.Filters"
-play.filters.headers.contentSecurityPolicy= "default-src 'self' 'unsafe-inline' localhost:9000 localhost:9032 localhost:9250 www.google-analytics.com data:"
+play.filters.headers.contentSecurityPolicy= "default-src 'self' 'unsafe-inline' localhost:9000 localhost:9032 localhost:9250 www.google-analytics.com data: www.googletagmanager.com fonts.googleapis.com tagmanager.google.com ssl.gstatic.com www.gstatic.com fonts.gstatic.com"
 
 # Play Modules
 # ~~~~


### PR DESCRIPTION
These are the changes I believe are necessary based on this page - https://confluence.tools.tax.service.gov.uk/display/TOOLS/Deploying+HMRC+Tax+Platform+GTM+Container and looking at this similar PR - https://github.com/hmrc/vat-agent-client-lookup-frontend/commit/bd6b344e63ce5de935e2d8726e8f4f72d68049f8