### PR TITLE
Additional hint text re: exports on supporting information pages.

### DIFF
--- a/app/views/supportingInformation.scala.html
+++ b/app/views/supportingInformation.scala.html
@@ -36,7 +36,8 @@
         @components.input_yes_no(
             field = form("value"),
             label = messages("supportingInformation.heading"),
-            labelClass = Some("heading-xlarge mb-2")
+            labelClass = Some("heading-xlarge mb-2"),
+            hint = Some(messages("supportingInformation.hint"))
         )
 
         @components.submit_button()

--- a/app/views/supportingInformationDetails.scala.html
+++ b/app/views/supportingInformationDetails.scala.html
@@ -36,7 +36,8 @@
         @components.input_textarea(
             field = form("value"),
             label = messages("supportingInformationDetails.heading"),
-            labelClass = Some("heading-xlarge mb-2")
+            labelClass = Some("heading-xlarge mb-2"),
+            hint = Some(messages("supportingInformationDetails.hint"))
         )
 
         @components.submit_button()

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -315,11 +315,13 @@ supportingInformation.title = Other information to support this application - GO
 supportingInformation.heading = Do you need to enter any other information to support this application?
 supportingInformation.yesInformation = Yes
 supportingInformation.noInformation = No
+supportingInformation.hint = Tell us if the item is going to be exported.
 supportingInformation.checkYourAnswersLabel = Do you have supporting information?
 supportingInformation.error.required = Select yes if you want to enter any supporting information
 
 supportingInformationDetails.title = Enter supporting information - GOV.UK
 supportingInformationDetails.heading = What is the information you want to provide?
+supportingInformationDetails.hint = Tell us if the item will be exported and any other relevant information.
 supportingInformationDetails.checkYourAnswersLabel = Supporting information
 supportingInformationDetails.error.required = Enter supporting information
 supportingInformationDetails.error.length = Enter supporting information must be 100 characters or less

--- a/test/unit/views/CommodityCodeRulingReferenceViewSpec.scala
+++ b/test/unit/views/CommodityCodeRulingReferenceViewSpec.scala
@@ -16,9 +16,11 @@
 
 package views
 
+import controllers.routes
 import forms.CommodityCodeRulingReferenceFormProvider
 import models.NormalMode
 import play.api.data.Form
+import play.twirl.api.HtmlFormat
 import views.behaviours.StringViewBehaviours
 import views.html.commodityCodeRulingReference
 
@@ -28,16 +30,21 @@ class CommodityCodeRulingReferenceViewSpec extends StringViewBehaviours {
 
   val form = new CommodityCodeRulingReferenceFormProvider()()
 
-  def createView = () => commodityCodeRulingReference(frontendAppConfig, form, NormalMode)(fakeRequest, messages)
+  def createView: () => HtmlFormat.Appendable = () => commodityCodeRulingReference(frontendAppConfig, form, NormalMode)(fakeRequest, messages)
 
-  def createViewUsingForm = (form: Form[String]) => commodityCodeRulingReference(frontendAppConfig, form, NormalMode)(fakeRequest, messages)
+  def createViewUsingForm: Form[String] => HtmlFormat.Appendable = (form: Form[String]) =>
+    commodityCodeRulingReference(frontendAppConfig, form, NormalMode)(fakeRequest, messages)
 
   "CommodityCodeRulingReference view" must {
     behave like normalPage(createView, messageKeyPrefix)()
 
     behave like pageWithBackLink(createView)
 
-    // TODO scaffold test cannot cope with text-area with no label
-//    behave like textareaPage(createViewUsingForm, messageKeyPrefix, routes.CommodityCodeRulingReferenceController.onSubmit(NormalMode).url)
+    behave like textareaPage(
+      createViewUsingForm,
+      messageKeyPrefix,
+      routes.CommodityCodeRulingReferenceController.onSubmit(NormalMode).url,
+      Some(s"$messageKeyPrefix.hint")
+    )
   }
 }

--- a/test/unit/views/SupportingInformationDetailsViewSpec.scala
+++ b/test/unit/views/SupportingInformationDetailsViewSpec.scala
@@ -20,6 +20,7 @@ import controllers.routes
 import forms.SupportingInformationDetailsFormProvider
 import models.NormalMode
 import play.api.data.Form
+import play.twirl.api.HtmlFormat
 import views.behaviours.StringViewBehaviours
 import views.html.supportingInformationDetails
 
@@ -29,15 +30,21 @@ class SupportingInformationDetailsViewSpec extends StringViewBehaviours {
 
   val form = new SupportingInformationDetailsFormProvider()()
 
-  def createView = () => supportingInformationDetails(frontendAppConfig, form, NormalMode)(fakeRequest, messages)
+  def createView: () => HtmlFormat.Appendable = () => supportingInformationDetails(frontendAppConfig, form, NormalMode)(fakeRequest, messages)
 
-  def createViewUsingForm = (form: Form[String]) => supportingInformationDetails(frontendAppConfig, form, NormalMode)(fakeRequest, messages)
+  def createViewUsingForm: Form[String] => HtmlFormat.Appendable = (form: Form[String]) =>
+    supportingInformationDetails(frontendAppConfig, form, NormalMode)(fakeRequest, messages)
 
   "SupportingInformationDetails view" must {
     behave like normalPage(createView, messageKeyPrefix)()
 
     behave like pageWithBackLink(createView)
 
-    behave like textareaPage(createViewUsingForm, messageKeyPrefix, routes.SupportingInformationDetailsController.onSubmit(NormalMode).url)
+    behave like textareaPage(
+      createViewUsingForm,
+      messageKeyPrefix,
+      routes.SupportingInformationDetailsController.onSubmit(NormalMode).url,
+      Some(s"$messageKeyPrefix.hint")
+    )
   }
 }

--- a/test/unit/views/ViewSpecBase.scala
+++ b/test/unit/views/ViewSpecBase.scala
@@ -78,12 +78,18 @@ trait ViewSpecBase extends SpecBase {
     assert(labels.size == 1, s"\n\nLabel for $forElement was not rendered on the page.")
     val label = labels.first
 
-    if (expectedHintText.isDefined) {
-      assert(label.getElementsByClass("form-hint").first.text == expectedHintText.get,
-        s"\n\nLabel for $forElement did not contain hint text $expectedHintText")
+    def assertLabel(label: Element, expectedText: String, forElement: String) = {
+      assert(label.text() == expectedText, s"\n\nLabel for $forElement was not $expectedText")
     }
 
-    assert(label.text() == expectedText, s"\n\nLabel for $forElement was not $expectedText")
+    expectedHintText match {
+      case Some(hint) => {
+        assert(label.getElementsByClass("form-hint").first.text == hint,
+          s"\n\nLabel for $forElement did not contain hint text $hint")
+        assertLabel(label, s"$expectedText $hint", forElement)
+      }
+      case _ => assertLabel(label, expectedText, forElement)
+    }
   }
 
   def assertElementHasClass(doc: Document, id: String, expectedClass: String): Assertion = {


### PR DESCRIPTION
Fixed view specs to assert labels with/without hints