### PR TITLE
Tactical fix - restrict number of characters users can enter into all…

### DIFF
--- a/app/views/components/input_textarea.scala.html
+++ b/app/views/components/input_textarea.scala.html
@@ -22,7 +22,8 @@
         labelClass: Option[String] = None,
         hint: Option[String] = None,
         htmlHint: Option[Html] = None,
-        numRows: Int = 5
+        numRows: Int = 5,
+        maxlength: Int = 90000
 )(implicit messages: Messages)
 
 <div class="form-group @if(field.hasErrors){form-group-error}">
@@ -44,6 +45,7 @@
             id="@{field.id}"
             name="@{field.id}"
             rows=@numRows
+            maxlength=@maxlength
             @if(field.hasErrors){aria-describedby="error-message-@{field.id}-input"}>@{field.value}</textarea>
     </div>
 </div>


### PR DESCRIPTION
… text-areas.

This solves the immediate problem of https://jira.tools.tax.service.gov.uk/browse/DIT-922

If we want to do a "nicer" solution then that ticket will need further design input (error message, number of valid chars per form, etc.)