### PR TITLE
DIT-2274 | Fixed error message display for select lists

### DIFF
--- a/app/views/components/select.scala.html
+++ b/app/views/components/select.scala.html
@@ -40,7 +40,9 @@
 
     @if(elements.args.contains('_additionalTitleText)){<p>@elements.args.get('_additionalTitleText)</p>}
     @if(elements.hasErrors){
-        @{ elements.errors.map { error => <div id="error-message-@{field.id}-input" class="error-message"><span class="visually-hidden">@messages("error.browser.title.prefix")</span>@messages(error)</div>} }
+        @elements.errors.map { error =>
+            <div id="error-message-@{field.id}-input" class="error-message"><span class="visually-hidden">@messages("error.browser.title.prefix")</span>@error</div>
+        }
     }
     <select @if(elements.hasErrors || elements.args.contains('_inputHint)){aria-describedby="@if(elements.args.contains('_inputHint) ){hint-@elements.field.name} @if(elements.hasErrors){error-message-@{field.id}-input}"} id="@elements.field.name" name="@elements.field.name" class="@elements.args.get('_selectClass) form-control">
         @if(displayEmptyValue) {


### PR DESCRIPTION
The `elements.errors` sequence has already read the message from `messages` using the `FieldElements` helper (https://github.com/hmrc/binding-tariff-trader-frontend/blob/master/app/views/components/select.scala.html#L22).