### PR TITLE
DIT-2287 Add metrics collection code

### DIFF
--- a/app/connectors/BindingTariffClassificationConnector.scala
+++ b/app/connectors/BindingTariffClassificationConnector.scala
@@ -17,44 +17,50 @@
 package connectors
 
 import com.google.inject.Inject
+import com.kenshoo.play.metrics.Metrics
 import config.FrontendAppConfig
 import javax.inject.Singleton
+import metrics.HasMetrics
 import models.CaseStatus.CaseStatus
 import models._
 import models.requests.NewEventRequest
+import scala.concurrent.{ ExecutionContext, Future }
 import uk.gov.hmrc.http.HeaderCarrier
 import utils.JsonFormatters._
 
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
-
 @Singleton
 class BindingTariffClassificationConnector @Inject()(
-                                                      client: AuthenticatedHttpClient
-                                                    )(implicit configuration: FrontendAppConfig) extends InjectAuthHeader {
+  client: AuthenticatedHttpClient,
+  val metrics: Metrics
+)(implicit configuration: FrontendAppConfig, ec: ExecutionContext) extends InjectAuthHeader with HasMetrics {
 
-  def createCase(c: NewCaseRequest)(implicit hc: HeaderCarrier): Future[Case] = {
-    val url = s"${configuration.bindingTariffClassificationUrl}/cases"
-    client.POST[NewCaseRequest, Case](url = url, body = c)(implicitly, implicitly, addAuth, implicitly)
-  }
+  def createCase(c: NewCaseRequest)(implicit hc: HeaderCarrier): Future[Case] =
+    withMetricsTimerAsync("create-case") { _ =>
+      val url = s"${configuration.bindingTariffClassificationUrl}/cases"
+      client.POST[NewCaseRequest, Case](url = url, body = c)(implicitly, implicitly, addAuth, implicitly)
+    }
 
-  def findCase(reference: String)(implicit hc: HeaderCarrier): Future[Option[Case]] = {
-    val url = s"${configuration.bindingTariffClassificationUrl}/cases/$reference"
-    client.GET[Option[Case]](url)(implicitly, addAuth, implicitly)
-  }
+  def findCase(reference: String)(implicit hc: HeaderCarrier): Future[Option[Case]] =
+    withMetricsTimerAsync("get-case-by-reference") { _ =>
+      val url = s"${configuration.bindingTariffClassificationUrl}/cases/$reference"
+      client.GET[Option[Case]](url)(implicitly, addAuth, implicitly)
+    }
 
-  def findCasesBy(eori: String, status: Set[CaseStatus], pagination: Pagination, sort: Sort)(implicit hc: HeaderCarrier): Future[Paged[Case]] = {
-    val url = s"${configuration.bindingTariffClassificationUrl}/cases" +
-      s"?eori=$eori&status=${status.mkString(",")}" +
-      s"&sort_by=${sort.field}&sort_direction=${sort.direction}" +
-      s"&page=${pagination.page}&page_size=${pagination.pageSize}" +
-      "&migrated=false"
-    client.GET[Paged[Case]](url)(implicitly, addAuth, implicitly)
-  }
+  def findCasesBy(eori: String, status: Set[CaseStatus], pagination: Pagination, sort: Sort)(implicit hc: HeaderCarrier): Future[Paged[Case]] =
+    withMetricsTimerAsync("search-cases") { _ =>
+      val url = s"${configuration.bindingTariffClassificationUrl}/cases" +
+        s"?eori=$eori&status=${status.mkString(",")}" +
+        s"&sort_by=${sort.field}&sort_direction=${sort.direction}" +
+        s"&page=${pagination.page}&page_size=${pagination.pageSize}" +
+        "&migrated=false"
 
-  def createEvent(c: Case, e: NewEventRequest)(implicit hc: HeaderCarrier): Future[Event] = {
-    val url = s"${configuration.bindingTariffClassificationUrl}/cases/${c.reference}/events"
-    client.POST[NewEventRequest, Event](url = url, body = e)(implicitly, implicitly, addAuth, implicitly)
-  }
+      client.GET[Paged[Case]](url)(implicitly, addAuth, implicitly)
+    }
+
+  def createEvent(c: Case, e: NewEventRequest)(implicit hc: HeaderCarrier): Future[Event] =
+    withMetricsTimerAsync("create-event") { _ =>
+      val url = s"${configuration.bindingTariffClassificationUrl}/cases/${c.reference}/events"
+      client.POST[NewEventRequest, Event](url = url, body = e)(implicitly, implicitly, addAuth, implicitly)
+    }
 
 }

--- a/app/connectors/BindingTariffFilestoreConnector.scala
+++ b/app/connectors/BindingTariffFilestoreConnector.scala
@@ -19,8 +19,10 @@ package connectors
 import akka.stream.IOResult
 import akka.stream.scaladsl.{FileIO, Source}
 import akka.util.ByteString
+import com.kenshoo.play.metrics.Metrics
 import config.FrontendAppConfig
 import javax.inject.{Inject, Singleton}
+import metrics.HasMetrics
 import models.response.FilestoreResponse
 import models.{Attachment, FileAttachment}
 import play.api.libs.Files.TemporaryFile
@@ -28,55 +30,56 @@ import play.api.libs.json.Json
 import play.api.libs.ws.WSClient
 import play.api.mvc.MultipartFormData
 import play.api.mvc.MultipartFormData.FilePart
+import scala.concurrent.{ ExecutionContext, Future }
 import uk.gov.hmrc.http.HeaderCarrier
-
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
 
 @Singleton
 class BindingTariffFilestoreConnector @Inject()(
-                                                 ws: WSClient,
-                                                 client: AuthenticatedHttpClient
-                                               )(implicit appConfig: FrontendAppConfig) extends InjectAuthHeader {
+  ws: WSClient,
+  client: AuthenticatedHttpClient,
+  val metrics: Metrics
+)(implicit appConfig: FrontendAppConfig, ec: ExecutionContext) extends InjectAuthHeader with HasMetrics {
 
   def upload(file: MultipartFormData.FilePart[TemporaryFile])
-            (implicit hc: HeaderCarrier): Future[FilestoreResponse] = {
+            (implicit hc: HeaderCarrier): Future[FilestoreResponse] = 
+    withMetricsTimerAsync("upload-file") { _ =>
+      val filePart: MultipartFormData.Part[Source[ByteString, Future[IOResult]]] = FilePart(
+        "file",
+        file.filename,
+        file.contentType,
+        FileIO.fromPath(file.ref.path)
+      )
 
-    val filePart: MultipartFormData.Part[Source[ByteString, Future[IOResult]]] = FilePart(
-      "file",
-      file.filename,
-      file.contentType,
-      FileIO.fromPath(file.ref.path)
-    )
-
-    ws.url(s"${appConfig.bindingTariffFileStoreUrl}/file")
-      .addHttpHeaders(hc.headers: _*)
-      .addHttpHeaders(authHeaders(appConfig.apiToken))
-      .post(Source(List(filePart)))
-      .map(response => Json.fromJson[FilestoreResponse](Json.parse(response.body)).get)
-
-  }
-
-  def get(file: FileAttachment)(implicit hc: HeaderCarrier): Future[FilestoreResponse] = {
-    client.GET[FilestoreResponse](s"${appConfig.bindingTariffFileStoreUrl}/file/${file.id}")(implicitly, addAuth, implicitly)
-  }
-
-  def publish(file: FileAttachment)(implicit hc: HeaderCarrier): Future[FilestoreResponse] = {
-    client.POSTEmpty[FilestoreResponse](s"${appConfig.bindingTariffFileStoreUrl}/file/${file.id}/publish")(implicitly, addAuth, implicitly)
-  }
-
-  def getFileMetadata(attachments: Seq[Attachment])(implicit headerCarrier: HeaderCarrier): Future[Seq[FilestoreResponse]] = {
-    if (attachments.isEmpty) {
-      Future.successful(Seq.empty)
-    } else {
-      val query = s"?${attachments.map(att => s"id=${att.id}").mkString("&")}"
-      val url = s"${appConfig.bindingTariffFileStoreUrl}/file$query"
-      client.GET[Seq[FilestoreResponse]](url)(implicitly, addAuth, implicitly)
+      ws.url(s"${appConfig.bindingTariffFileStoreUrl}/file")
+        .addHttpHeaders(hc.headers: _*)
+        .addHttpHeaders(authHeaders(appConfig.apiToken))
+        .post(Source(List(filePart)))
+        .map(response => Json.fromJson[FilestoreResponse](Json.parse(response.body)).get)
     }
-  }
 
-  def get(attachment: Attachment)(implicit headerCarrier: HeaderCarrier): Future[Option[FilestoreResponse]] = {
-    client.GET[Option[FilestoreResponse]](s"${appConfig.bindingTariffFileStoreUrl}/file/${attachment.id}")(implicitly, addAuth, implicitly)
-  }
+  def get(file: FileAttachment)(implicit hc: HeaderCarrier): Future[FilestoreResponse] =
+    withMetricsTimerAsync("get-file-by-id") { _ =>
+      client.GET[FilestoreResponse](s"${appConfig.bindingTariffFileStoreUrl}/file/${file.id}")(implicitly, addAuth, implicitly)
+    }
 
+  def publish(file: FileAttachment)(implicit hc: HeaderCarrier): Future[FilestoreResponse] =
+    withMetricsTimerAsync("publish-file") { _ =>
+      client.POSTEmpty[FilestoreResponse](s"${appConfig.bindingTariffFileStoreUrl}/file/${file.id}/publish")(implicitly, addAuth, implicitly)
+    }
+
+  def getFileMetadata(attachments: Seq[Attachment])(implicit headerCarrier: HeaderCarrier): Future[Seq[FilestoreResponse]] =
+    withMetricsTimerAsync("get-file-metadata") { _ =>
+      if (attachments.isEmpty) {
+        Future.successful(Seq.empty)
+      } else {
+        val query = s"?${attachments.map(att => s"id=${att.id}").mkString("&")}"
+        val url = s"${appConfig.bindingTariffFileStoreUrl}/file$query"
+        client.GET[Seq[FilestoreResponse]](url)(implicitly, addAuth, implicitly)
+      }
+    }
+
+  def get(attachment: Attachment)(implicit headerCarrier: HeaderCarrier): Future[Option[FilestoreResponse]] =
+    withMetricsTimerAsync("get-file-by-id") { _ =>
+      client.GET[Option[FilestoreResponse]](s"${appConfig.bindingTariffFileStoreUrl}/file/${attachment.id}")(implicitly, addAuth, implicitly)
+    }
 }

--- a/app/connectors/DataCacheConnector.scala
+++ b/app/connectors/DataCacheConnector.scala
@@ -17,32 +17,39 @@
 package connectors
 
 import com.google.inject.Inject
+import com.kenshoo.play.metrics.Metrics
+import metrics.HasMetrics
 import play.api.libs.json.Format
 import repositories.SessionRepository
+import scala.concurrent.{ ExecutionContext, Future }
 import uk.gov.hmrc.http.cache.client.CacheMap
 
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+class MongoCacheConnector @Inject()(
+  val sessionRepository: SessionRepository,
+  val metrics: Metrics
+)(implicit ec: ExecutionContext) extends DataCacheConnector with HasMetrics {
 
-class MongoCacheConnector @Inject()(val sessionRepository: SessionRepository) extends DataCacheConnector {
-
-  def save[A](cacheMap: CacheMap): Future[CacheMap] = {
-    sessionRepository().upsert(cacheMap).map {_ => cacheMap}
-  }
+  def save[A](cacheMap: CacheMap): Future[CacheMap] =
+    withMetricsTimerAsync("mongo-cache-save") { _ =>
+      sessionRepository().upsert(cacheMap).map { _ => cacheMap }
+    }
 
   def fetch(cacheId: String): Future[Option[CacheMap]] =
-    sessionRepository().get(cacheId)
-
-  def getEntry[A](cacheId: String, key: String)(implicit fmt: Format[A]): Future[Option[A]] = {
-    fetch(cacheId).map { optionalCacheMap =>
-      optionalCacheMap.flatMap { cacheMap => cacheMap.getEntry(key)}
+    withMetricsTimerAsync("mongo-cache-fetch") { _ =>
+      sessionRepository().get(cacheId)
     }
-  }
 
-  def remove(cacheMap: CacheMap): Future[Boolean] = {
-    sessionRepository().remove(cacheMap)
-  }
+  def getEntry[A](cacheId: String, key: String)(implicit fmt: Format[A]): Future[Option[A]] =
+    withMetricsTimerAsync("mongo-cache-get-entry") { _ =>
+      fetch(cacheId).map { optionalCacheMap =>
+        optionalCacheMap.flatMap { cacheMap => cacheMap.getEntry(key)}
+      }
+    }
 
+  def remove(cacheMap: CacheMap): Future[Boolean] =
+    withMetricsTimerAsync("mongo-cache-remove") { _ =>
+      sessionRepository().remove(cacheMap)
+    }
 }
 
 trait DataCacheConnector {

--- a/app/connectors/EmailConnector.scala
+++ b/app/connectors/EmailConnector.scala
@@ -17,23 +17,26 @@
 package connectors
 
 import com.google.inject.Inject
+import com.kenshoo.play.metrics.Metrics
 import config.FrontendAppConfig
 import javax.inject.Singleton
+import metrics.HasMetrics
 import models.Email
-import play.api.libs.json.{Reads, Writes}
+import play.api.libs.json.{ Reads, Writes }
+import scala.concurrent.{ ExecutionContext, Future }
 import uk.gov.hmrc.http.HeaderCarrier
-import uk.gov.hmrc.play.bootstrap.http.HttpClient
-
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
-import uk.gov.hmrc.http.HttpResponse
+import uk.gov.hmrc.http.HttpClient
 
 @Singleton
-class EmailConnector @Inject()(configuration: FrontendAppConfig, client: HttpClient) {
+class EmailConnector @Inject()(
+  configuration: FrontendAppConfig,
+  client: HttpClient,
+  val metrics: Metrics
+)(implicit ec: ExecutionContext) extends HasMetrics {
 
-  def send[E >: Email[_]](e: E)(implicit hc: HeaderCarrier, writes: Writes[E], rds: Reads[E]): Future[Unit] = {
-    val url = s"${configuration.emailUrl}/hmrc/email"
-    client.POST(url = url, body = e).map(_ => ())
-  }
-
+  def send[E >: Email[_]](e: E)(implicit hc: HeaderCarrier, writes: Writes[E], rds: Reads[E]): Future[Unit] =
+    withMetricsTimerAsync("send-email") { _ =>
+      val url = s"${configuration.emailUrl}/hmrc/email"
+      client.POST(url = url, body = e).map(_ => ())
+    }
 }

--- a/app/metrics/HasMetrics.scala
+++ b/app/metrics/HasMetrics.scala
@@ -61,14 +61,14 @@ trait HasMetrics {
 
     def completeWithSuccess(): Unit = {
       if (timerRunning.compareAndSet(true, false)) {
-        timer.stop()
+        localMetrics.stopTimer(timer)
         localMetrics.incrementSuccessCounter(metric)
       }
     }
 
     def completeWithFailure(): Unit = {
       if (timerRunning.compareAndSet(true, false)) {
-        timer.stop()
+        localMetrics.stopTimer(timer)
         localMetrics.incrementFailedCounter(metric)
       }
     }

--- a/app/metrics/HasMetrics.scala
+++ b/app/metrics/HasMetrics.scala
@@ -19,12 +19,11 @@ package metrics
 import com.codahale.metrics.{ MetricRegistry, Timer }
 import com.kenshoo.play.metrics.Metrics
 import java.util.concurrent.atomic.AtomicBoolean
-import play.api.mvc.{ Action, Result }
+import play.api.mvc.{ Action, BaseController, Result }
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.util.control.NonFatal
-import play.api.mvc.AbstractController
 
-trait HasActionMetrics extends HasMetrics { self: AbstractController =>
+trait HasActionMetrics extends HasMetrics { self: BaseController =>
   /**
     * Execute a [[play.api.mvc.Action]] with a metrics timer.
     * Intended for use in controllers that return HTTP responses.

--- a/app/metrics/HasMetrics.scala
+++ b/app/metrics/HasMetrics.scala
@@ -19,11 +19,11 @@ package metrics
 import com.codahale.metrics.{ MetricRegistry, Timer }
 import com.kenshoo.play.metrics.Metrics
 import java.util.concurrent.atomic.AtomicBoolean
-import play.api.mvc.{ Action, BaseController, Result }
+import play.api.mvc.{ Action, MessagesBaseController, Result }
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.util.control.NonFatal
 
-trait HasActionMetrics extends HasMetrics { self: BaseController =>
+trait HasActionMetrics extends HasMetrics { self: MessagesBaseController =>
   /**
     * Execute a [[play.api.mvc.Action]] with a metrics timer.
     * Intended for use in controllers that return HTTP responses.

--- a/app/metrics/HasMetrics.scala
+++ b/app/metrics/HasMetrics.scala
@@ -20,7 +20,6 @@ import com.codahale.metrics.{ MetricRegistry, Timer }
 import com.kenshoo.play.metrics.Metrics
 import java.util.concurrent.atomic.AtomicBoolean
 import play.api.mvc.Result
-import play.api.http.Status
 import scala.concurrent.{ ExecutionContext, Future }
 
 trait HasMetrics {
@@ -73,7 +72,7 @@ trait HasMetrics {
 
       // Clean up timer according to server response
       result.foreach { result =>
-        if (Status.isServerError(result.header.status))
+        if (isFailureStatus(result.header.status))
           timer.completeWithFailure()
         else
           timer.completeWithSuccess()
@@ -125,4 +124,7 @@ trait HasMetrics {
 
   private def withMetricsTimer[T](metric: Metric)(block: MetricsTimer => T): T =
     block(new MetricsTimer(metric))
+
+  private def isFailureStatus(status: Int) =
+    status / 100 >= 4
 }

--- a/app/metrics/HasMetrics.scala
+++ b/app/metrics/HasMetrics.scala
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package metrics
+
+import com.codahale.metrics.{ MetricRegistry, Timer }
+import com.kenshoo.play.metrics.Metrics
+import java.util.concurrent.atomic.AtomicBoolean
+import play.api.mvc.Result
+import play.api.http.Status
+import scala.concurrent.{ ExecutionContext, Future }
+
+trait HasMetrics {
+  type Metric = String
+
+  def metrics: Metrics
+
+  lazy val registry: MetricRegistry = metrics.defaultRegistry
+
+  val localMetrics = new LocalMetrics
+
+  class LocalMetrics {
+    def startTimer(metric: Metric) = registry.timer(s"$metric-timer").time()
+    def stopTimer(context: Timer.Context) = context.stop()
+    def incrementSuccessCounter(metric: Metric): Unit = registry.counter(s"$metric-success-counter").inc()
+    def incrementFailedCounter(metric: Metric): Unit = registry.counter(s"$metric-failed-counter").inc()
+  }
+
+  class MetricsTimer(metric: Metric) {
+    val timer = localMetrics.startTimer(metric)
+    val timerRunning = new AtomicBoolean(true)
+
+    def completeWithSuccess(): Unit = {
+      if (timerRunning.compareAndSet(true, false)) {
+        timer.stop()
+        localMetrics.incrementSuccessCounter(metric)
+      }
+    }
+
+    def completeWithFailure(): Unit = {
+      if (timerRunning.compareAndSet(true, false)) {
+        timer.stop()
+        localMetrics.incrementFailedCounter(metric)
+      }
+    }
+  }
+
+  /**
+    * Execute a block of code with a metrics timer.
+    * Intended for use in controllers that return HTTP responses.
+    *
+    * @param metric The id of the metric to be collected
+    * @param block The block of code to execute asynchronously
+    * @param ec The [[scala.concurrent.ExecutionContext]] on which the block of code should run
+    * @return The result of the block of code
+    */
+  def withMetricsTimerAction(metric: Metric)(block: => Future[Result])(implicit ec: ExecutionContext): Future[Result] = {
+    withMetricsTimer(metric) { timer =>
+      val result = block
+
+      // Clean up timer according to server response
+      result.foreach { result =>
+        if (Status.isServerError(result.header.status))
+          timer.completeWithFailure()
+        else
+          timer.completeWithSuccess()
+      }
+
+      // Clean up timer for unhandled exceptions
+      result.failed.foreach { _ =>
+        timer.completeWithFailure()
+      }
+
+      result
+    }
+  }
+
+  /**
+    * Execute a block of code with a metrics timer.
+    * 
+    * Intended for use in connectors that call other microservices.
+    * 
+    * It's expected that the user of this method might want to handle
+    * connector failures gracefully and therefore they are given a [[MetricsTimer]]
+    * to optionally record whether the call was a success or a failure.
+    * 
+    * If the user does not specify otherwise the status of the result Future is
+    * used to determine whether the block was successful or not.
+    * 
+    * @param metric The id of the metric to be collected
+    * @param block The block of code to execute asynchronously
+    * @param ec The [[scala.concurrent.ExecutionContext]] on which the block of code should run
+    * @return The result of the block of code
+    */
+  def withMetricsTimerAsync[T](metric: Metric)(block: MetricsTimer => Future[T])(implicit ec: ExecutionContext): Future[T] = {
+    withMetricsTimer(metric) { timer =>
+      val result = block(timer)
+
+      // Clean up timer if the user doesn't
+      result.foreach { _ =>
+        timer.completeWithSuccess()
+      }
+
+      // Clean up timer on unhandled exceptions
+      result.failed.foreach { _ =>
+        timer.completeWithFailure()
+      }
+
+      result
+    }
+  }
+
+  private def withMetricsTimer[T](metric: Metric)(block: MetricsTimer => T): T =
+    block(new MetricsTimer(metric))
+}

--- a/test/unit/connectors/BindingTariffClassificationConnectorSpec.scala
+++ b/test/unit/connectors/BindingTariffClassificationConnectorSpec.scala
@@ -26,9 +26,11 @@ import play.api.libs.json.Json
 import uk.gov.hmrc.http.{HeaderCarrier, NotFoundException, Upstream5xxResponse}
 import utils.JsonFormatters._
 
+import scala.concurrent.ExecutionContext.Implicits.global
+
 class BindingTariffClassificationConnectorSpec extends ConnectorTest {
 
-  private val connector = new BindingTariffClassificationConnector(authenticatedHttpClient)(mockConfig)
+  private val connector = new BindingTariffClassificationConnector(authenticatedHttpClient, metrics)(mockConfig, implicitly)
 
   private def withHeaderCarrier(key: String, value: String) = HeaderCarrier(extraHeaders = Seq(key -> value))
 

--- a/test/unit/connectors/BindingTariffFilestoreConnectorSpec.scala
+++ b/test/unit/connectors/BindingTariffFilestoreConnectorSpec.scala
@@ -25,9 +25,11 @@ import play.api.libs.Files.TemporaryFile
 import play.api.mvc.MultipartFormData
 import uk.gov.hmrc.http.HeaderCarrier
 
+import scala.concurrent.ExecutionContext.Implicits.global
+
 class BindingTariffFilestoreConnectorSpec extends ConnectorTest {
 
-  private def connector = new BindingTariffFilestoreConnector(wsClient, authenticatedHttpClient)(mockConfig)
+  private def connector = new BindingTariffFilestoreConnector(wsClient, authenticatedHttpClient, metrics)(mockConfig, implicitly)
 
   private def withHeaderCarrier(key: String, value: String) = HeaderCarrier(extraHeaders = Seq(key -> value))
 

--- a/test/unit/connectors/ConnectorTest.scala
+++ b/test/unit/connectors/ConnectorTest.scala
@@ -18,6 +18,7 @@ package connectors
 
 import akka.actor.ActorSystem
 import base.SpecBase
+import com.kenshoo.play.metrics.Metrics
 import config.FrontendAppConfig
 import org.mockito.Mockito.when
 import org.scalatest.BeforeAndAfterAll
@@ -26,6 +27,7 @@ import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.audit.http.HttpAuditing
 import uk.gov.hmrc.play.bootstrap.http.DefaultHttpClient
 import unit.base.WireMockObject
+import unit.utils.TestMetrics
 
 import scala.io.Source
 
@@ -37,6 +39,7 @@ trait ConnectorTest
 
   protected lazy val fakeAuthToken = "AUTH_TOKEN"
   protected lazy val wsClient: WSClient = injector.instanceOf[WSClient]
+  protected lazy val metrics: Metrics = new TestMetrics
   protected lazy val authenticatedHttpClient = new AuthenticatedHttpClient(
     auditing,
     wsClient,

--- a/test/unit/connectors/EmailConnectorSpec.scala
+++ b/test/unit/connectors/EmailConnectorSpec.scala
@@ -22,9 +22,11 @@ import models.{ApplicationSubmittedEmail, ApplicationSubmittedParameters}
 import org.apache.http.HttpStatus
 import uk.gov.hmrc.http.Upstream5xxResponse
 
+import scala.concurrent.ExecutionContext.Implicits.global
+
 class EmailConnectorSpec extends ConnectorTest {
 
-  private val connector = new EmailConnector(mockConfig, standardHttpClient)
+  private val connector = new EmailConnector(mockConfig, standardHttpClient, metrics)
 
   private val email = ApplicationSubmittedEmail(Seq("user@domain.com"), ApplicationSubmittedParameters("ref", "name"))
 

--- a/test/unit/connectors/MongoCacheConnectorSpec.scala
+++ b/test/unit/connectors/MongoCacheConnectorSpec.scala
@@ -30,8 +30,13 @@ import uk.gov.hmrc.http.cache.client.CacheMap
 
 import scala.concurrent.Future
 
-class MongoCacheConnectorSpec extends WordSpec with MustMatchers with ScalaCheckDrivenPropertyChecks
-  with Generators with MockitoSugar with ScalaFutures with OptionValues {
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class MongoCacheConnectorSpec
+  extends ConnectorTest
+  with ScalaCheckDrivenPropertyChecks
+  with Generators
+  with ScalaFutures {
 
   ".save" must {
 
@@ -43,14 +48,14 @@ class MongoCacheConnectorSpec extends WordSpec with MustMatchers with ScalaCheck
       when(mockSessionRepository.apply()) thenReturn mockReactiveMongoRepository
       when(mockReactiveMongoRepository.upsert(any[CacheMap])) thenReturn Future.successful(true)
 
-      val mongoCacheConnector = new MongoCacheConnector(mockSessionRepository)
+      val mongoCacheConnector = new MongoCacheConnector(mockSessionRepository, metrics)
 
       forAll(arbitrary[CacheMap]) { cacheMap =>
 
         val result = mongoCacheConnector.save(cacheMap)
 
         whenReady(result) { savedCacheMap =>
-          savedCacheMap mustEqual cacheMap
+          savedCacheMap shouldEqual cacheMap
           verify(mockReactiveMongoRepository).upsert(cacheMap)
         }
 
@@ -70,14 +75,14 @@ class MongoCacheConnectorSpec extends WordSpec with MustMatchers with ScalaCheck
       when(mockSessionRepository.apply()) thenReturn mockReactiveMongoRepository
       when(mockReactiveMongoRepository.remove(any[CacheMap])) thenReturn Future.successful(true)
 
-      val mongoCacheConnector = new MongoCacheConnector(mockSessionRepository)
+      val mongoCacheConnector = new MongoCacheConnector(mockSessionRepository, metrics)
 
       forAll(arbitrary[CacheMap]) { cacheMap =>
 
         val result = mongoCacheConnector.remove(cacheMap)
 
         whenReady(result) { savedCacheMap =>
-          savedCacheMap mustEqual true
+          savedCacheMap shouldEqual true
           verify(mockReactiveMongoRepository).remove(cacheMap)
         }
       }
@@ -98,14 +103,14 @@ class MongoCacheConnectorSpec extends WordSpec with MustMatchers with ScalaCheck
         when(mockSessionRepository.apply()) thenReturn mockReactiveMongoRepository
         when(mockReactiveMongoRepository.get(any())) thenReturn Future.successful(None)
 
-        val mongoCacheConnector = new MongoCacheConnector(mockSessionRepository)
+        val mongoCacheConnector = new MongoCacheConnector(mockSessionRepository, metrics)
 
         forAll(nonEmptyString) { cacheId =>
 
           val result = mongoCacheConnector.fetch(cacheId)
 
           whenReady(result) { optionalCacheMap =>
-            optionalCacheMap must be(empty)
+            optionalCacheMap should be(empty)
           }
         }
 
@@ -122,7 +127,7 @@ class MongoCacheConnectorSpec extends WordSpec with MustMatchers with ScalaCheck
 
         when(mockSessionRepository.apply()) thenReturn mockReactiveMongoRepository
 
-        val mongoCacheConnector = new MongoCacheConnector(mockSessionRepository)
+        val mongoCacheConnector = new MongoCacheConnector(mockSessionRepository, metrics)
 
         forAll(arbitrary[CacheMap]) { cacheMap =>
 
@@ -131,7 +136,7 @@ class MongoCacheConnectorSpec extends WordSpec with MustMatchers with ScalaCheck
           val result = mongoCacheConnector.fetch(cacheMap.id)
 
           whenReady(result) { optionalCacheMap =>
-              optionalCacheMap.value mustEqual cacheMap
+            optionalCacheMap shouldBe Some(cacheMap)
           }
         }
 
@@ -153,14 +158,14 @@ class MongoCacheConnectorSpec extends WordSpec with MustMatchers with ScalaCheck
         when(mockSessionRepository.apply()) thenReturn mockReactiveMongoRepository
         when(mockReactiveMongoRepository.get(any())) thenReturn Future.successful(None)
 
-        val mongoCacheConnector = new MongoCacheConnector(mockSessionRepository)
+        val mongoCacheConnector = new MongoCacheConnector(mockSessionRepository, metrics)
 
         forAll(nonEmptyString, nonEmptyString) { (cacheId, key) =>
 
             val result = mongoCacheConnector.getEntry[String](cacheId, key)
 
             whenReady(result) { optionalValue =>
-              optionalValue must be(empty)
+              optionalValue should be(empty)
             }
         }
 
@@ -177,7 +182,7 @@ class MongoCacheConnectorSpec extends WordSpec with MustMatchers with ScalaCheck
 
         when(mockSessionRepository.apply()) thenReturn mockReactiveMongoRepository
 
-        val mongoCacheConnector = new MongoCacheConnector(mockSessionRepository)
+        val mongoCacheConnector = new MongoCacheConnector(mockSessionRepository, metrics)
 
         val gen = for {
           key      <- nonEmptyString
@@ -191,7 +196,7 @@ class MongoCacheConnectorSpec extends WordSpec with MustMatchers with ScalaCheck
           val result = mongoCacheConnector.getEntry[String](cacheMap.id, k)
 
           whenReady(result) { optionalValue =>
-            optionalValue must be(empty)
+            optionalValue should be(empty)
           }
         }
 
@@ -208,7 +213,7 @@ class MongoCacheConnectorSpec extends WordSpec with MustMatchers with ScalaCheck
 
         when(mockSessionRepository.apply()) thenReturn mockReactiveMongoRepository
 
-        val mongoCacheConnector = new MongoCacheConnector(mockSessionRepository)
+        val mongoCacheConnector = new MongoCacheConnector(mockSessionRepository, metrics)
 
         val gen = for {
           key      <- nonEmptyString
@@ -222,7 +227,7 @@ class MongoCacheConnectorSpec extends WordSpec with MustMatchers with ScalaCheck
           val result = mongoCacheConnector.getEntry[String](cacheMap.id, k)
 
           whenReady(result) { optionalValue =>
-            optionalValue.value mustEqual v
+            optionalValue shouldBe Some(v)
           }
         }
 

--- a/test/unit/connectors/PdfGeneratorServiceConnectorSpec.scala
+++ b/test/unit/connectors/PdfGeneratorServiceConnectorSpec.scala
@@ -21,11 +21,13 @@ import models.PdfFile
 import play.api.http.Status
 import play.twirl.api.Html
 
+import scala.concurrent.ExecutionContext.Implicits.global
+
 class PdfGeneratorServiceConnectorSpec extends ConnectorTest {
 
   private val pdfTemplate = Html("")
 
-  private val connector = new PdfGeneratorServiceConnector(mockConfig, wsClient)
+  private val connector = new PdfGeneratorServiceConnector(mockConfig, wsClient, metrics)
 
   "Connector" should {
 

--- a/test/unit/metrics/HasMetricsSpec.scala
+++ b/test/unit/metrics/HasMetricsSpec.scala
@@ -24,11 +24,9 @@ import org.mockito.ArgumentMatchers._
 import org.scalatest.{ AsyncWordSpecLike, BeforeAndAfterAll, Matchers, OptionValues }
 import org.scalatest.compatible.Assertion
 import org.scalatestplus.mockito.MockitoSugar
-import play.api.mvc.Results
+import play.api.mvc.{ MessagesAbstractController, Results }
+import play.api.test.{ FakeRequest, Helpers }
 import scala.concurrent.Future
-import play.api.test.Helpers
-import play.api.test.FakeRequest
-import play.api.mvc.AbstractController
 
 class HasMetricsSpec extends AsyncWordSpecLike with Matchers with OptionValues with MockitoSugar with BeforeAndAfterAll {
 
@@ -44,7 +42,7 @@ class HasMetricsSpec extends AsyncWordSpecLike with Matchers with OptionValues w
     with MockHasMetrics
 
   class TestHasActionMetrics
-    extends AbstractController(Helpers.stubControllerComponents())
+    extends MessagesAbstractController(Helpers.stubMessagesControllerComponents())
     with HasActionMetrics
     with MockHasMetrics
 

--- a/test/unit/metrics/HasMetricsSpec.scala
+++ b/test/unit/metrics/HasMetricsSpec.scala
@@ -57,7 +57,7 @@ class HasMetricsSpec extends AsyncWordSpecLike with Matchers with OptionValues w
   def verifyCompletedWithSuccess(metricName: String, metrics: MockHasMetrics): Assertion = {
     val inOrder = Mockito.inOrder(metrics.localMetrics, metrics.timer)
     inOrder.verify(metrics.localMetrics, times(1)).startTimer(metricName)
-    inOrder.verify(metrics.timer, times(1)).stop()
+    inOrder.verify(metrics.localMetrics, times(1)).stopTimer(metrics.timer)
     inOrder.verify(metrics.localMetrics, times(1)).incrementSuccessCounter(metricName)
     verifyNoMoreInteractions(metrics.localMetrics)
     verifyNoMoreInteractions(metrics.timer)
@@ -67,7 +67,7 @@ class HasMetricsSpec extends AsyncWordSpecLike with Matchers with OptionValues w
   def verifyCompletedWithFailure(metricName: String, metrics: MockHasMetrics): Assertion = {
     val inOrder = Mockito.inOrder(metrics.localMetrics, metrics.timer)
     inOrder.verify(metrics.localMetrics, times(1)).startTimer(metricName)
-    inOrder.verify(metrics.timer, times(1)).stop()
+    inOrder.verify(metrics.localMetrics, times(1)).stopTimer(metrics.timer)
     inOrder.verify(metrics.localMetrics, times(1)).incrementFailedCounter(metricName)
     verifyNoMoreInteractions(metrics.localMetrics)
     verifyNoMoreInteractions(metrics.timer)

--- a/test/unit/metrics/HasMetricsSpec.scala
+++ b/test/unit/metrics/HasMetricsSpec.scala
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package metrics
+
+import com.codahale.metrics.Timer
+import com.kenshoo.play.metrics.Metrics
+import org.mockito.Mockito
+import org.mockito.Mockito._
+import org.mockito.ArgumentMatchers._
+import org.scalatest.{ AsyncWordSpecLike, BeforeAndAfterAll, Matchers, OptionValues }
+import org.scalatest.mockito.MockitoSugar
+import org.scalatest.compatible.Assertion
+import play.api.mvc.Results
+import scala.concurrent.Future
+
+class HasMetricsSpec extends AsyncWordSpecLike with Matchers with OptionValues with MockitoSugar with BeforeAndAfterAll {
+  class TestHasMetrics extends HasMetrics {
+    val timer = mock[Timer.Context]
+    val metrics = mock[Metrics]
+    override val localMetrics: LocalMetrics = mock[LocalMetrics]
+    when(localMetrics.startTimer(anyString())) thenReturn timer
+  }
+
+  def withTestMetrics[A](test: TestHasMetrics => A): A = {
+    test(new TestHasMetrics)
+  }
+
+  def verifyCompletedWithSuccess(metricName: String, metrics: TestHasMetrics): Assertion = {
+    val inOrder = Mockito.inOrder(metrics.localMetrics, metrics.timer)
+    inOrder.verify(metrics.localMetrics, times(1)).startTimer(metricName)
+    inOrder.verify(metrics.timer, times(1)).stop()
+    inOrder.verify(metrics.localMetrics, times(1)).incrementSuccessCounter(metricName)
+    verifyNoMoreInteractions(metrics.localMetrics)
+    verifyNoMoreInteractions(metrics.timer)
+    succeed
+  }
+
+  def verifyCompletedWithFailure(metricName: String, metrics: TestHasMetrics): Assertion = {
+    val inOrder = Mockito.inOrder(metrics.localMetrics, metrics.timer)
+    inOrder.verify(metrics.localMetrics, times(1)).startTimer(metricName)
+    inOrder.verify(metrics.timer, times(1)).stop()
+    inOrder.verify(metrics.localMetrics, times(1)).incrementFailedCounter(metricName)
+    verifyNoMoreInteractions(metrics.localMetrics)
+    verifyNoMoreInteractions(metrics.timer)
+    succeed
+  }
+
+  val TestMetric = "test-metric"
+
+  "HasMetrics" when {
+    "withMetricsTimerAsync" should {
+      "increment success counter for a successful future" in withTestMetrics { metrics =>
+        metrics.withMetricsTimerAsync(TestMetric){ _ =>
+          Future.successful(())
+        }.map { _ =>
+          verifyCompletedWithSuccess(TestMetric, metrics)
+        }
+      }
+
+      "increment success counter for a successful future where completeWithSuccess is called explicitly" in withTestMetrics { metrics =>
+        metrics.withMetricsTimerAsync(TestMetric) { timer =>
+          timer.completeWithSuccess()
+          Future.successful(())
+        }.map { _ =>
+          verifyCompletedWithSuccess(TestMetric, metrics)
+        }
+      }
+
+      "increment failure counter for a failed future" in withTestMetrics { metrics =>
+        metrics.withMetricsTimerAsync(TestMetric){ _ =>
+          Future.failed(new Exception)
+        }.recover { case _ =>
+          verifyCompletedWithFailure(TestMetric, metrics)
+        }
+      }
+
+      "increment failure counter for a successful future where completeWithFailure is called explicitly" in withTestMetrics { metrics =>
+        metrics.withMetricsTimerAsync(TestMetric) { timer =>
+          timer.completeWithFailure()
+          Future.successful(())
+        }.map { _ =>
+          verifyCompletedWithFailure(TestMetric, metrics)
+        }
+      }
+
+      "only increment counters once regardless of how many times the user calls complete with success" in withTestMetrics { metrics =>
+        metrics.withMetricsTimerAsync(TestMetric) { timer =>
+          Future { timer.completeWithSuccess() }
+          Future { timer.completeWithSuccess() }
+          Future { timer.completeWithSuccess() }
+          Future { timer.completeWithSuccess() }
+          Future.successful(())
+        }.map { _ =>
+          verifyCompletedWithSuccess(TestMetric, metrics)
+        }
+      }
+
+      "only increment counters once regardless of how many times the user calls complete with failure" in withTestMetrics { metrics =>
+        metrics.withMetricsTimerAsync(TestMetric) { timer =>
+          Future { timer.completeWithFailure() }
+          Future { timer.completeWithFailure() }
+          Future { timer.completeWithFailure() }
+          Future { timer.completeWithFailure() }
+          timer.completeWithFailure()
+          Future.successful(())
+        }.map { _ =>
+          verifyCompletedWithFailure(TestMetric, metrics)
+        }
+      }
+    }
+
+    "withMetricsTimerAction" should {
+      "increment success counter for a successful future of an informational Result" in withTestMetrics { metrics =>
+        metrics.withMetricsTimerAction(TestMetric) {
+          Future.successful(Results.Continue)
+        }.map { _ =>
+          verifyCompletedWithSuccess(TestMetric, metrics)
+        }
+      }
+
+      "increment success counter for a successful future of a successful Result" in withTestMetrics { metrics =>
+        metrics.withMetricsTimerAction(TestMetric) {
+          Future.successful(Results.Ok)
+        }.map { _ =>
+          verifyCompletedWithSuccess(TestMetric, metrics)
+        }
+      }
+
+      "increment success counter for a successful future of a redirect Result" in withTestMetrics { metrics =>
+        metrics.withMetricsTimerAction(TestMetric) {
+          Future.successful(Results.NotModified)
+        }.map { _ =>
+          verifyCompletedWithSuccess(TestMetric, metrics)
+        }
+      }
+
+      "increment failure counter for a successful future of a client error Result" in withTestMetrics { metrics =>
+        metrics.withMetricsTimerAction(TestMetric) {
+          Future.successful(Results.EntityTooLarge)
+        }.map { _ =>
+          verifyCompletedWithFailure(TestMetric, metrics)
+        }
+      }
+
+      "increment failure counter for a successful future of a server error Result" in withTestMetrics { metrics =>
+        metrics.withMetricsTimerAction(TestMetric) {
+          Future.successful(Results.BadGateway)
+        }.map { _ =>
+          verifyCompletedWithFailure(TestMetric, metrics)
+        }
+      }
+
+      "increment failure counter for a failed future" in withTestMetrics { metrics =>
+        metrics.withMetricsTimerAction(TestMetric) {
+          Future.failed(new Exception)
+        }.transformWith { case _ =>
+          verifyCompletedWithFailure(TestMetric, metrics)
+        }
+      }
+
+    }
+  }
+
+}

--- a/test/unit/utils/TestMetrics.scala
+++ b/test/unit/utils/TestMetrics.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package unit.utils
+
+import com.kenshoo.play.metrics.Metrics
+import com.codahale.metrics.MetricRegistry
+
+class TestMetrics extends Metrics {
+  override def defaultRegistry: MetricRegistry = new MetricRegistry
+  override def toJson: String = ""
+}


### PR DESCRIPTION
This PR adds a `HasMetrics` trait for use in services and connectors inspired by [similar code](https://github.com/hmrc/pertax-frontend/blob/master/app/metrics/HasMetrics.scala) in pertax-frontend.

I have changed the code somewhat so that it is harder to leak timers by forgetting to stop them or by failing to handle exceptions in the code block that is being executed.

The approach I have used is to try and ensure that the `completeWithSuccess` and `completeWithFailure` methods on the timer are idempotent, that is, whatever code stops the timer first should win and further attempts to stop it should do nothing.

The provided combinators then stop the timer on completion of the Future block regardless of whether the user did so.