### PR TITLE
DIT-2287 Fix flakey tests in SignoutControllerSpec

### DIFF
--- a/test/unit/controllers/SignOutControllerSpec.scala
+++ b/test/unit/controllers/SignOutControllerSpec.scala
@@ -54,7 +54,7 @@ class SignOutControllerSpec extends ControllerSpecBase with BeforeAndAfterEach {
     }
 
     "clear user cache when present" in {
-      controller.startFeedbackSurvey(fakeRequestWithEoriAndCache)
+      await(controller.startFeedbackSurvey(fakeRequestWithEoriAndCache))
       verify(dataCache).remove(any())
     }
   }
@@ -69,7 +69,7 @@ class SignOutControllerSpec extends ControllerSpecBase with BeforeAndAfterEach {
     }
 
     "clear user cache when present" in {
-      controller.forceSignOut(fakeRequestWithEoriAndCache)
+      await(controller.forceSignOut(fakeRequestWithEoriAndCache))
       verify(dataCache).remove(any())
     }
   }


### PR DESCRIPTION
These tests didn't await the Future returned by the controller methods so they were flakey when verifying the mock calls.