### PR TITLE
DIT-2383 Don't use CSRF token in Upscan form

### DIFF
--- a/app/views/uploadSupportingMaterialMultiple.scala.html
+++ b/app/views/uploadSupportingMaterialMultiple.scala.html
@@ -18,8 +18,7 @@
 @import controllers.routes._
 @import models.Mode
 @import models.response.FileStoreInitiateResponse
-@import uk.gov.hmrc.play.views.html._
-@import views.html.helper.CSRF
+@import views.html.helper.{form, CSRF}
 @import views.ViewUtils._
 
 @(appConfig: FrontendAppConfig, initiateResponse: FileStoreInitiateResponse, form: Form[_], goodsName: String, mode: Mode)(implicit request: Request[_], messages: Messages)
@@ -29,7 +28,7 @@
     appConfig = appConfig,
     bodyClasses = None) {
 
-    @helpers.form(
+    @helper.form(
         action = Call("POST", initiateResponse.uploadRequest.href),
         'enctype -> "multipart/form-data",
         'id -> "upload-files-form") {


### PR DESCRIPTION
This seems to cause an error at S3:

errorCode=AccessDenied
errorMessage=Invalid+according+to+Policy%3A+Extra+input+fields%3A+csrftoken