### PR TITLE
Dit 2526 - Added new parameter shouldPublishToRuling for the attachment tab in Operational service

### DIFF
--- a/app/controllers/CheckYourAnswersController.scala
+++ b/app/controllers/CheckYourAnswersController.scala
@@ -123,7 +123,8 @@ class CheckYourAnswersController @Inject()(
     }
 
     val withStatus = fileAttachments
-      .map(att => Attachment(att.id, public = !keepConfidential(att.id)))
+      .map(att => Attachment(att.id, public = !keepConfidential(att.id), shouldPublishToRulings = if(keepConfidential(att.id)) true else false))
+
 
     for {
       published   <- fileService.publish(fileAttachments)

--- a/app/controllers/CheckYourAnswersController.scala
+++ b/app/controllers/CheckYourAnswersController.scala
@@ -26,7 +26,7 @@ import models._
 import models.requests.DataRequest
 import navigation.Navigator
 import pages._
-import play.api.i18n.{I18nSupport, Lang}
+import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents, Result}
 import service.{CasesService, CountriesService, FileService}
 import uk.gov.hmrc.http.HeaderCarrier
@@ -123,7 +123,7 @@ class CheckYourAnswersController @Inject()(
     }
 
     val withStatus = fileAttachments
-      .map(att => Attachment(att.id, public = !keepConfidential(att.id), shouldPublishToRulings = if(keepConfidential(att.id)) true else false))
+      .map(att => Attachment(att.id, public = !keepConfidential(att.id), shouldPublishToRulings = if(keepConfidential(att.id)) false else true))
 
 
     for {

--- a/app/models/Attachment.scala
+++ b/app/models/Attachment.scala
@@ -24,7 +24,8 @@ case class Attachment
 (
   id: String,
   public: Boolean,
-  timestamp: ZonedDateTime = ZonedDateTime.now()
+  timestamp: ZonedDateTime = ZonedDateTime.now(),
+  shouldPublishToRulings : Boolean
 )
 
 object Attachment {

--- a/app/models/Attachment.scala
+++ b/app/models/Attachment.scala
@@ -25,7 +25,7 @@ case class Attachment
   id: String,
   public: Boolean,
   timestamp: ZonedDateTime = ZonedDateTime.now(),
-  shouldPublishToRulings : Boolean
+  shouldPublishToRulings: Boolean
 )
 
 object Attachment {

--- a/app/views/components/back_link.scala.html
+++ b/app/views/components/back_link.scala.html
@@ -17,5 +17,5 @@
 @()(implicit messages: Messages)
 
 <div class="js-visible">
-  <p class="back-link-text"><a id="back-link" class="link-back" href="#">@messages("site.back")</a></p>
+ <p class="back-link-text"><a id="back-link" class="link-back" href="#">@messages("site.back")</a></p>
 </div>

--- a/test/unit/connectors/BindingTariffFilestoreConnectorSpec.scala
+++ b/test/unit/connectors/BindingTariffFilestoreConnectorSpec.scala
@@ -176,7 +176,9 @@ class BindingTariffFilestoreConnectorSpec extends ConnectorTest {
       )
 
       await(
-        connector.getFileMetadata(Seq(Attachment("id1", false), Attachment("id2", false)))(withHeaderCarrier("X-Api-Token", appConfig.apiToken))
+        connector.getFileMetadata(Seq(Attachment("id1", public = false, shouldPublishToRulings = false),
+          Attachment("id2", public = false, shouldPublishToRulings = false)))
+        (withHeaderCarrier("X-Api-Token", appConfig.apiToken))
       ) shouldBe Seq(
         FilestoreResponse(
           id = "id1",

--- a/test/unit/models/oCase.scala
+++ b/test/unit/models/oCase.scala
@@ -22,7 +22,7 @@ import java.util.UUID
 import viewmodels.{FileView, PdfViewModel}
 
 object oCase {
-  val fileAttachment = Attachment(id = UUID.randomUUID().toString, false)
+  val fileAttachment = Attachment(id = UUID.randomUUID().toString, public = false, shouldPublishToRulings = false)
   val eoriDetailsExample = EORIDetails("eoriTrader", "Trader Business Name", "line1", "line2", "line3", "postcode", "country")
   val eoriAgentDetailsExample = AgentDetails(EORIDetails("eoriAgent", "Agent Business Name", "line1", "line2", "line3", "postcode", "country"),
     Some(fileAttachment))

--- a/test/unit/service/FileServiceSpec.scala
+++ b/test/unit/service/FileServiceSpec.scala
@@ -244,7 +244,8 @@ class FileServiceSpec extends SpecBase with BeforeAndAfterEach {
   private def anAttachmentWithId(id: String): Attachment = {
     Attachment(
       id = id,
-      public = true
+      public = true,
+      shouldPublishToRulings = true
     )
   }
 


### PR DESCRIPTION
This should be merged after https://github.com/hmrc/binding-tariff-classification/pull/157
