### PR TITLE
Avoid use of temporary files due to seeming JDK regression

### DIFF
--- a/app/connectors/BindingTariffFilestoreConnector.scala
+++ b/app/connectors/BindingTariffFilestoreConnector.scala
@@ -30,57 +30,66 @@ import play.api.libs.json.Json
 import play.api.libs.ws.WSClient
 import play.api.mvc.MultipartFormData
 import play.api.mvc.MultipartFormData.FilePart
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.{ExecutionContext, Future}
 import uk.gov.hmrc.http.HeaderCarrier
 import models.requests.FileStoreInitiateRequest
 import models.response.FileStoreInitiateResponse
 import play.api.mvc.MultipartFormData.DataPart
 import play.api.libs.json.JsResult
+import akka.NotUsed
 
 @Singleton
-class BindingTariffFilestoreConnector @Inject()(
+class BindingTariffFilestoreConnector @Inject() (
   ws: WSClient,
   client: AuthenticatedHttpClient,
   val metrics: Metrics
-)(implicit appConfig: FrontendAppConfig, ec: ExecutionContext) extends InjectAuthHeader with HasMetrics {
+)(implicit appConfig: FrontendAppConfig, ec: ExecutionContext)
+    extends InjectAuthHeader
+    with HasMetrics {
 
   def get(file: FileAttachment)(implicit hc: HeaderCarrier): Future[FilestoreResponse] =
     withMetricsTimerAsync("get-file-by-id") { _ =>
-      client.GET[FilestoreResponse](s"${appConfig.bindingTariffFileStoreUrl}/file/${file.id}")(implicitly, addAuth, implicitly)
+      client.GET[FilestoreResponse](s"${appConfig.bindingTariffFileStoreUrl}/file/${file.id}")(
+        implicitly,
+        addAuth,
+        implicitly
+      )
     }
 
-  def initiate(request: FileStoreInitiateRequest)(implicit hc: HeaderCarrier): Future[FileStoreInitiateResponse] = {
+  def initiate(request: FileStoreInitiateRequest)(implicit hc: HeaderCarrier): Future[FileStoreInitiateResponse] =
     withMetricsTimerAsync("initiate-file-upload") { _ =>
       client.POST[FileStoreInitiateRequest, FileStoreInitiateResponse](
-        s"${appConfig.bindingTariffFileStoreUrl}/file/initiate", request
+        s"${appConfig.bindingTariffFileStoreUrl}/file/initiate",
+        request
       )(implicitly, implicitly, addAuth, implicitly)
     }
-  }
 
-  def uploadApplicationPdf(reference: String, file: TemporaryFile)
-          (implicit hc: HeaderCarrier): Future[FilestoreResponse] =
-  withMetricsTimerAsync("upload-file") { _ =>
-    val dataPart: MultipartFormData.DataPart = DataPart("publish", "true")
-    val filePart: MultipartFormData.Part[Source[ByteString, Future[IOResult]]] = FilePart(
-      "file",
-      s"ATaRApplication_${reference}.pdf",
-      Some("application/pdf"),
-      FileIO.fromPath(file.path)
-    )
-    ws.url(s"${appConfig.bindingTariffFileStoreUrl}/file")
-      .addHttpHeaders(hc.headers: _*)
-      .addHttpHeaders(authHeaders(appConfig.apiToken))
-      .post(Source(List(dataPart, filePart)))
-      .flatMap { response =>
-        Future.fromTry {
-          JsResult.toTry(Json.fromJson[FilestoreResponse](Json.parse(response.body)))
+  def uploadApplicationPdf(reference: String, content: Array[Byte])(
+    implicit hc: HeaderCarrier
+  ): Future[FilestoreResponse] =
+    withMetricsTimerAsync("upload-file") { _ =>
+      val dataPart: MultipartFormData.DataPart = DataPart("publish", "true")
+      val filePart: MultipartFormData.Part[Source[ByteString, NotUsed]] = FilePart(
+        "file",
+        s"ATaRApplication_$reference.pdf",
+        Some("application/pdf"),
+        Source.single(ByteString(content))
+      )
+      ws.url(s"${appConfig.bindingTariffFileStoreUrl}/file")
+        .addHttpHeaders(hc.headers: _*)
+        .addHttpHeaders(authHeaders(appConfig.apiToken))
+        .post(Source(List(dataPart, filePart)))
+        .flatMap { response =>
+          Future.fromTry {
+            JsResult.toTry(Json.fromJson[FilestoreResponse](Json.parse(response.body)))
+          }
         }
-      }
-  }
+    }
 
   def downloadFile(url: String)(implicit hc: HeaderCarrier): Future[Option[Source[ByteString, _]]] =
     withMetricsTimerAsync("download-file") { _ =>
-      val fileStoreResponse = ws.url(url)
+      val fileStoreResponse = ws
+        .url(url)
         .withHttpHeaders(hc.headers: _*)
         .withHttpHeaders(authHeaders(appConfig.apiToken))
         .get()
@@ -89,7 +98,7 @@ class BindingTariffFilestoreConnector @Inject()(
         if (response.status / 100 == 2)
           Future.successful(Some(response.bodyAsSource))
         else if (response.status / 100 > 4)
-          Future.failed(new RuntimeException(s"Unable to retrieve file ${url} from filestore"))
+          Future.failed(new RuntimeException(s"Unable to retrieve file $url from filestore"))
         else
           Future.successful(None)
       }
@@ -97,22 +106,32 @@ class BindingTariffFilestoreConnector @Inject()(
 
   def publish(file: FileAttachment)(implicit hc: HeaderCarrier): Future[FilestoreResponse] =
     withMetricsTimerAsync("publish-file") { _ =>
-      client.POSTEmpty[FilestoreResponse](s"${appConfig.bindingTariffFileStoreUrl}/file/${file.id}/publish")(implicitly, addAuth, implicitly)
+      client.POSTEmpty[FilestoreResponse](s"${appConfig.bindingTariffFileStoreUrl}/file/${file.id}/publish")(
+        implicitly,
+        addAuth,
+        implicitly
+      )
     }
 
-  def getFileMetadata(attachments: Seq[Attachment])(implicit headerCarrier: HeaderCarrier): Future[Seq[FilestoreResponse]] =
+  def getFileMetadata(
+    attachments: Seq[Attachment]
+  )(implicit headerCarrier: HeaderCarrier): Future[Seq[FilestoreResponse]] =
     withMetricsTimerAsync("get-file-metadata") { _ =>
       if (attachments.isEmpty) {
         Future.successful(Seq.empty)
       } else {
         val query = s"?${attachments.map(att => s"id=${att.id}").mkString("&")}"
-        val url = s"${appConfig.bindingTariffFileStoreUrl}/file$query"
+        val url   = s"${appConfig.bindingTariffFileStoreUrl}/file$query"
         client.GET[Seq[FilestoreResponse]](url)(implicitly, addAuth, implicitly)
       }
     }
 
   def get(attachment: Attachment)(implicit headerCarrier: HeaderCarrier): Future[Option[FilestoreResponse]] =
     withMetricsTimerAsync("get-file-by-id") { _ =>
-      client.GET[Option[FilestoreResponse]](s"${appConfig.bindingTariffFileStoreUrl}/file/${attachment.id}")(implicitly, addAuth, implicitly)
+      client.GET[Option[FilestoreResponse]](s"${appConfig.bindingTariffFileStoreUrl}/file/${attachment.id}")(
+        implicitly,
+        addAuth,
+        implicitly
+      )
     }
 }

--- a/app/controllers/CheckYourAnswersController.scala
+++ b/app/controllers/CheckYourAnswersController.scala
@@ -136,7 +136,7 @@ class CheckYourAnswersController @Inject()(
 
       pdf = PdfViewModel(atar, fileView)
       pdfFile <- pdfService.generatePdf(views.html.components.view_application_pdf(appConfig, pdf, getCountryName))
-      pdfStored <- fileService.uploadApplicationPdf(atar.reference, createApplicationPdf(atar.reference, pdfFile))
+      pdfStored <- fileService.uploadApplicationPdf(atar.reference, pdfFile.content)
       pdfAttachment = Attachment(pdfStored.id, false)
       caseUpdate = CaseUpdate(Some(ApplicationUpdate(
         applicationPdf = SetValue(Some(pdfAttachment))
@@ -155,12 +155,6 @@ class CheckYourAnswersController @Inject()(
     attachments: Seq[Attachment]
   )(implicit headerCarrier: HeaderCarrier): Future[Case] = {
     caseService.create(newCaseRequest.copy(attachments = attachments))
-  }
-
-  def createApplicationPdf(reference: String, pdf: PdfFile): TemporaryFile = {
-    val tempFile = tempFileCreator.create(reference, "pdf")
-    Files.write(tempFile.path, pdf.content, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE)
-    tempFile
   }
 
   private def getCountryName(code: String): Option[String] =

--- a/app/service/FileService.scala
+++ b/app/service/FileService.scala
@@ -50,8 +50,8 @@ class FileService @Inject()(
     connector.initiate(request)
   }
 
-  def uploadApplicationPdf(reference: String, f: TemporaryFile)(implicit hc: HeaderCarrier): Future[FileAttachment] = {
-    connector.uploadApplicationPdf(reference, f).map(toFileAttachment(f.path.toFile.length))
+  def uploadApplicationPdf(reference: String, content: Array[Byte])(implicit hc: HeaderCarrier): Future[FileAttachment] = {
+    connector.uploadApplicationPdf(reference, content).map(toFileAttachment(content.length.toLong))
   }
 
   def downloadFile(url: String)(implicit hc: HeaderCarrier): Future[Option[Source[ByteString, _]]] =

--- a/app/workers/MigrationWorker.scala
+++ b/app/workers/MigrationWorker.scala
@@ -98,12 +98,6 @@ class MigrationWorker @Inject() (
   private def getCountryName(code: String): Option[String] =
     countriesService.getAllCountriesById.get(code).map(_.countryName)
 
-  private def createApplicationPdf(reference: String, pdf: PdfFile): TemporaryFile = {
-    val tempFile = tempFileCreator.create(reference, "pdf")
-    Files.write(tempFile.path, pdf.content, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.WRITE)
-    tempFile
-  }
-
   def regeneratePdf(cse: Case): Future[Unit] =
     for {
       meta <- fileService.getAttachmentMetadata(cse)
@@ -121,7 +115,7 @@ class MigrationWorker @Inject() (
 
       pdfFile <- pdfService.generatePdf(view_application_pdf(appConfig, pdfModel, getCountryName))
 
-      pdfStored <- fileService.uploadApplicationPdf(cse.reference, createApplicationPdf(cse.reference, pdfFile))
+      pdfStored <- fileService.uploadApplicationPdf(cse.reference, pdfFile.content)
 
       creationTime = ZonedDateTime.ofInstant(clock.instant(), clock.getZone())
 

--- a/test/unit/controllers/CheckYourAnswersControllerSpec.scala
+++ b/test/unit/controllers/CheckYourAnswersControllerSpec.scala
@@ -237,7 +237,7 @@ class CheckYourAnswersControllerSpec extends ControllerSpecBase with BeforeAndAf
   }
 
   private def givenTheApplicationPdfIsUploaded(): Unit = {
-    when(fileService.uploadApplicationPdf(any[String], any[TemporaryFile])(any[HeaderCarrier])).thenReturn(successful(applicationPdf))
+    when(fileService.uploadApplicationPdf(any[String], any[Array[Byte]])(any[HeaderCarrier])).thenReturn(successful(applicationPdf))
   }
 
   private def givenTheCaseIsUpdatedWithPdf(): Unit = {

--- a/test/unit/service/FileServiceSpec.scala
+++ b/test/unit/service/FileServiceSpec.scala
@@ -83,12 +83,10 @@ class FileServiceSpec extends SpecBase with BeforeAndAfterEach {
 
   "Upload" should {
     val filestoreResponse = FilestoreResponse("id", "some.pdf", "application/pdf")
-    val tempFile = SingletonTemporaryFileCreator.create("foo", "pdf")
-
     "Delegate to connector" in {
-      given(connector.uploadApplicationPdf(any[String], any[TemporaryFile])(any[HeaderCarrier])).willReturn(successful(filestoreResponse))
+      given(connector.uploadApplicationPdf(any[String], any[Array[Byte]])(any[HeaderCarrier])).willReturn(successful(filestoreResponse))
 
-      await(service.uploadApplicationPdf("foo", tempFile)) shouldBe FileAttachment("id", "some.pdf", "application/pdf", 0L, false)
+      await(service.uploadApplicationPdf("foo", Array.empty[Byte])) shouldBe FileAttachment("id", "some.pdf", "application/pdf", 0L, false)
     }
   }
 

--- a/test/unit/workers/MigrationWorkerSpec.scala
+++ b/test/unit/workers/MigrationWorkerSpec.scala
@@ -112,11 +112,11 @@ class MigrationWorkerSpec extends UnitSpec with MockitoSugar with BeforeAndAfter
       .willReturn(Future.successful(Seq.empty))
     given(pdfService.generatePdf(any[Html]))
       .willReturn(Future.successful(PdfFile(Array.empty, "application/pdf")))
-    given(fileService.uploadApplicationPdf(refEq("ref1"), any[Files.TemporaryFile])(any[HeaderCarrier]))
+    given(fileService.uploadApplicationPdf(refEq("ref1"), any[Array[Byte]])(any[HeaderCarrier]))
       .willReturn(Future.successful(FileAttachment("id1", "some.pdf", "application/pdf", 0L, true)))
-    given(fileService.uploadApplicationPdf(refEq("ref2"), any[Files.TemporaryFile])(any[HeaderCarrier]))
+    given(fileService.uploadApplicationPdf(refEq("ref2"), any[Array[Byte]])(any[HeaderCarrier]))
       .willReturn(Future.successful(FileAttachment("id2", "some.pdf", "application/pdf", 0L, true)))
-    given(fileService.uploadApplicationPdf(refEq("ref3"), any[Files.TemporaryFile])(any[HeaderCarrier]))
+    given(fileService.uploadApplicationPdf(refEq("ref3"), any[Array[Byte]])(any[HeaderCarrier]))
       .willReturn(Future.successful(FileAttachment("id3", "some.pdf", "application/pdf", 0L, true)))
   }
 


### PR DESCRIPTION
We have previously had problems in acceptance tests due to the problem reported here:

https://github.com/TheHive-Project/TheHive/issues/1089

Now we seem to have this in the migration worker which regenerates application PDFs, at the step where it uploads the temporary files to the file store.

In the acceptance tests we resolved this by downgrading the JDK, but in this case I can only suggest we avoid using temporary files entirely.