### PR TITLE
DDCE-3678: play-frontend-hmrc upgrade to remove any dependency on url…

### DIFF
--- a/app/audit/AuditService.scala
+++ b/app/audit/AuditService.scala
@@ -17,16 +17,16 @@
 package audit
 
 import audit.AuditPayloadType._
-import javax.inject.{Inject, Singleton}
 import models.{Application, Case}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.audit.DefaultAuditConnector
 import utils.JsonFormatters.caseAuditPayloadFormat
 
-import scala.concurrent.ExecutionContext.Implicits.global
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.ExecutionContext
 
 @Singleton
-class AuditService @Inject() (auditConnector: DefaultAuditConnector) {
+class AuditService @Inject() (auditConnector: DefaultAuditConnector)(implicit ec: ExecutionContext) {
 
   // TODO: TxM would like also the upscan file reference for each
   def auditBTIApplicationSubmissionSuccessful(c: Case)(implicit hc: HeaderCarrier): Unit = {

--- a/app/controllers/actions/DataRequiredAction.scala
+++ b/app/controllers/actions/DataRequiredAction.scala
@@ -22,10 +22,9 @@ import models.requests.{DataRequest, OptionalDataRequest}
 import play.api.mvc.Results.Redirect
 import play.api.mvc.{ActionRefiner, Result}
 
-import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.{ExecutionContext, Future}
 
-class DataRequiredActionImpl @Inject() extends DataRequiredAction {
+class DataRequiredActionImpl @Inject() (implicit ec: ExecutionContext) extends DataRequiredAction {
 
   override protected def refine[A](request: OptionalDataRequest[A]): Future[Either[Result, DataRequest[A]]] =
     request.userAnswers match {
@@ -34,7 +33,7 @@ class DataRequiredActionImpl @Inject() extends DataRequiredAction {
         Future.successful(Right(DataRequest(request.request, request.internalId, request.userEoriNumber, data)))
     }
 
-  override protected def executionContext: ExecutionContext = global
+  override protected def executionContext: ExecutionContext = ec
 }
 
 trait DataRequiredAction extends ActionRefiner[OptionalDataRequest, DataRequest]

--- a/app/controllers/actions/DataRetrievalAction.scala
+++ b/app/controllers/actions/DataRetrievalAction.scala
@@ -23,17 +23,17 @@ import models.requests.{IdentifierRequest, OptionalDataRequest}
 import play.api.mvc.ActionTransformer
 import uk.gov.hmrc.http.cache.client.CacheMap
 
-import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.{ExecutionContext, Future}
 
-class DataRetrievalActionImpl @Inject() (val dataCacheConnector: DataCacheConnector) extends DataRetrievalAction {
+class DataRetrievalActionImpl @Inject() (val dataCacheConnector: DataCacheConnector)(implicit ec: ExecutionContext)
+    extends DataRetrievalAction {
 
   override protected def transform[A](request: IdentifierRequest[A]): Future[OptionalDataRequest[A]] =
     dataCacheConnector.fetch(request.identifier).map { maybeData: Option[CacheMap] =>
       OptionalDataRequest(request.request, request.identifier, request.eoriNumber, maybeData.map(UserAnswers(_)))
     }
 
-  override protected def executionContext: ExecutionContext = global
+  override protected def executionContext: ExecutionContext = ec
 }
 
 trait DataRetrievalAction extends ActionTransformer[IdentifierRequest, OptionalDataRequest]

--- a/app/repositories/SessionRepository.scala
+++ b/app/repositories/SessionRepository.scala
@@ -29,7 +29,7 @@ import uk.gov.hmrc.mongo.play.json.PlayMongoRepository
 import uk.gov.hmrc.mongo.play.json.formats.MongoJodaFormats
 
 import java.util.concurrent.TimeUnit
-import javax.inject.Inject
+import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
 
 case class DatedCacheMap(id: String, data: Map[String, JsValue], lastUpdated: DateTime = DateTime.now(DateTimeZone.UTC))
@@ -41,6 +41,7 @@ object DatedCacheMap {
   def apply(cacheMap: CacheMap): DatedCacheMap = DatedCacheMap(cacheMap.id, cacheMap.data)
 }
 
+@Singleton
 class SessionRepository @Inject() (config: Configuration, mongo: MongoComponent)(implicit ec: ExecutionContext)
     extends PlayMongoRepository[DatedCacheMap](
       collectionName = config.get[String]("appName"),

--- a/app/service/CasesService.scala
+++ b/app/service/CasesService.scala
@@ -24,11 +24,13 @@ import play.api.Logging
 import uk.gov.hmrc.http.HeaderCarrier
 
 import javax.inject.{Inject, Singleton}
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
-class CasesService @Inject() (connector: BindingTariffClassificationConnector, emailConnector: EmailConnector)
+class CasesService @Inject() (
+  connector: BindingTariffClassificationConnector,
+  emailConnector: EmailConnector
+)(implicit ec: ExecutionContext)
     extends Logging {
 
   def create(c: NewCaseRequest)(implicit hc: HeaderCarrier): Future[Case] =

--- a/app/service/FileService.scala
+++ b/app/service/FileService.scala
@@ -30,16 +30,16 @@ import play.api.mvc.{MessagesControllerComponents, MultipartFormData}
 import uk.gov.hmrc.http.HeaderCarrier
 
 import javax.inject.{Inject, Singleton}
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
 import scala.concurrent.Future.{sequence, successful}
+import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class FileService @Inject() (
   connector: BindingTariffFilestoreConnector,
   cc: MessagesControllerComponents,
   appConfig: FrontendAppConfig
-) extends Logging {
+)(implicit ec: ExecutionContext)
+    extends Logging {
 
   private val messagesApi: MessagesApi = cc.messagesApi
   private implicit val lang: Lang      = Lang.defaultLang

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -17,17 +17,7 @@ include "frontend.conf"
 play.allowGlobalApplication = true
 
 # this key is for local development only!
-cookie.encryption.key="gvBoGdgzqG1AarzF1LY0zQ=="
-
-# this key is for local development only!
 queryParameter.encryption=${cookie.encryption}
-
-# this key is for local development only!
-sso.encryption.key="P5xsJ9Nt+quxGZzB4DeLfw=="
-
-play.ws.acceptAnyCertificate=true
-
-cookie.deviceId.secret="some_secret"
 
 # Session configuration
 # ~~~~~

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -3,21 +3,21 @@ import play.core.PlayVersion.current
 
 object AppDependencies {
 
-  private val bootstrapPlayVersion = "7.11.0"
-  private val hmrcMongoPlayVersion = "0.73.0"
+  private val bootstrapPlayVersion = "7.13.0"
+  private val hmrcMongoPlayVersion = "0.74.0"
 
   private lazy val compile: Seq[ModuleID] = Seq(
     "commons-validator"            % "commons-validator"              % "1.7",
-    "uk.gov.hmrc"                  %% "play-frontend-hmrc"            % "3.32.0-play-28",
+    "uk.gov.hmrc"                  %% "play-frontend-hmrc"            % "6.4.0-play-28",
     "uk.gov.hmrc"                  %% "bootstrap-frontend-play-28"    % bootstrapPlayVersion,
     "uk.gov.hmrc"                  %% "http-caching-client"           % "10.0.0-play-28",
-    "uk.gov.hmrc"                  %% "play-language"                 % "5.3.0-play-28",
+    "uk.gov.hmrc"                  %% "play-language"                 % "6.1.0-play-28",
     "uk.gov.hmrc.mongo"            %% "hmrc-mongo-play-28"            % hmrcMongoPlayVersion,
     "commons-codec"                % "commons-codec"                  % "1.15",
     "uk.gov.hmrc"                  %% "play-allowlist-filter-play-28" % "1.1.0",
-    "uk.gov.hmrc"                  %% "play-json-union-formatter"     % "1.15.0-play-28",
-    "org.typelevel"                %% "cats-core"                     % "2.8.0",
-    "com.fasterxml.jackson.module" %% "jackson-module-scala"          % "2.14.0"
+    "uk.gov.hmrc"                  %% "play-json-union-formatter"     % "1.18.0-play-28",
+    "org.typelevel"                %% "cats-core"                     % "2.9.0",
+    "com.fasterxml.jackson.module" %% "jackson-module-scala"          % "2.14.2"
   )
 
   private lazy val test: Seq[ModuleID] = Seq(
@@ -25,11 +25,11 @@ object AppDependencies {
     "com.typesafe.play"      %% "play-test"               % current,
     "uk.gov.hmrc.mongo"      %% "hmrc-mongo-test-play-28" % hmrcMongoPlayVersion,
     "uk.gov.hmrc"            %% "bootstrap-test-play-28"  % bootstrapPlayVersion,
-    "org.scalatest"          %% "scalatest"               % "3.2.14",
-    "org.scalatestplus"      %% "mockito-4-6"             % "3.2.14.0",
+    "org.scalatest"          %% "scalatest"               % "3.2.15",
+    "org.scalatestplus"      %% "mockito-4-6"             % "3.2.15.0",
     "org.scalatestplus"      %% "scalacheck-1-16"         % "3.2.14.0",
     "com.vladsch.flexmark"   % "flexmark-all"             % "0.62.2",
-    "io.github.wolfendale"   %% "scalacheck-gen-regexp"   % "1.0.0"
+    "io.github.wolfendale"   %% "scalacheck-gen-regexp"   % "1.1.0"
   ).map(_ % Test)
 
   def apply(): Seq[ModuleID] = compile ++ test

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -7,17 +7,15 @@ object AppDependencies {
   private val hmrcMongoPlayVersion = "0.74.0"
 
   private lazy val compile: Seq[ModuleID] = Seq(
-    "commons-validator"            % "commons-validator"              % "1.7",
-    "uk.gov.hmrc"                  %% "play-frontend-hmrc"            % "6.4.0-play-28",
-    "uk.gov.hmrc"                  %% "bootstrap-frontend-play-28"    % bootstrapPlayVersion,
-    "uk.gov.hmrc"                  %% "http-caching-client"           % "10.0.0-play-28",
-    "uk.gov.hmrc"                  %% "play-language"                 % "6.1.0-play-28",
-    "uk.gov.hmrc.mongo"            %% "hmrc-mongo-play-28"            % hmrcMongoPlayVersion,
-    "commons-codec"                % "commons-codec"                  % "1.15",
-    "uk.gov.hmrc"                  %% "play-allowlist-filter-play-28" % "1.1.0",
-    "uk.gov.hmrc"                  %% "play-json-union-formatter"     % "1.18.0-play-28",
-    "org.typelevel"                %% "cats-core"                     % "2.9.0",
-    "com.fasterxml.jackson.module" %% "jackson-module-scala"          % "2.14.2"
+    "commons-validator"            % "commons-validator"           % "1.7",
+    "uk.gov.hmrc"                  %% "play-frontend-hmrc"         % "6.4.0-play-28",
+    "uk.gov.hmrc"                  %% "bootstrap-frontend-play-28" % bootstrapPlayVersion,
+    "uk.gov.hmrc"                  %% "http-caching-client"        % "10.0.0-play-28",
+    "uk.gov.hmrc.mongo"            %% "hmrc-mongo-play-28"         % hmrcMongoPlayVersion,
+    "commons-codec"                % "commons-codec"               % "1.15",
+    "uk.gov.hmrc"                  %% "play-json-union-formatter"  % "1.18.0-play-28",
+    "org.typelevel"                %% "cats-core"                  % "2.9.0",
+    "com.fasterxml.jackson.module" %% "jackson-module-scala"       % "2.14.2"
   )
 
   private lazy val test: Seq[ModuleID] = Seq(

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -24,7 +24,7 @@ object AppDependencies {
     "uk.gov.hmrc.mongo"      %% "hmrc-mongo-test-play-28" % hmrcMongoPlayVersion,
     "uk.gov.hmrc"            %% "bootstrap-test-play-28"  % bootstrapPlayVersion,
     "org.scalatest"          %% "scalatest"               % "3.2.15",
-    "org.scalatestplus"      %% "mockito-4-6"             % "3.2.15.0",
+    "org.mockito"            %% "mockito-scala-scalatest" % "1.17.12",
     "org.scalatestplus"      %% "scalacheck-1-16"         % "3.2.14.0",
     "com.vladsch.flexmark"   % "flexmark-all"             % "0.62.2",
     "io.github.wolfendale"   %% "scalacheck-gen-regexp"   % "1.1.0"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.6.2
+sbt.version=1.7.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,14 +3,14 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts
   Resolver.ivyStylePatterns
 )
 
-addSbtPlugin("com.typesafe.play"         % "sbt-plugin"             % "2.8.16")
+addSbtPlugin("com.typesafe.play"         % "sbt-plugin"             % "2.8.19")
 addSbtPlugin("com.typesafe.sbt"          % "sbt-digest"             % "1.1.4")
 addSbtPlugin("net.ground5hark.sbt"       % "sbt-concat"             % "0.2.0")
 addSbtPlugin("io.github.irundaia"        % "sbt-sassify"            % "1.5.2")
 addSbtPlugin("org.scalastyle"            %% "scalastyle-sbt-plugin" % "1.0.0")
 addSbtPlugin("org.scoverage"             % "sbt-scoverage"          % "2.0.0")
-addSbtPlugin("uk.gov.hmrc"               % "sbt-auto-build"         % "3.8.0")
-addSbtPlugin("uk.gov.hmrc"               % "sbt-distributables"     % "2.1.0")
+addSbtPlugin("uk.gov.hmrc"               % "sbt-auto-build"         % "3.9.0")
+addSbtPlugin("uk.gov.hmrc"               % "sbt-distributables"     % "2.2.0")
 addSbtPlugin("com.timushev.sbt"          % "sbt-updates"            % "0.6.3")
 addSbtPlugin("org.scalameta"             % "sbt-scalafmt"           % "2.4.6")
 addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat"           % "0.3.3")

--- a/test/unit/base/SpecBase.scala
+++ b/test/unit/base/SpecBase.scala
@@ -20,8 +20,8 @@ import akka.stream.Materializer
 import config.FrontendAppConfig
 import models.UserAnswers
 import models.requests.{DataRequest, IdentifierRequest, OptionalDataRequest}
+import org.mockito.MockitoSugar
 import org.scalatest.BeforeAndAfterEach
-import org.scalatestplus.mockito.MockitoSugar
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.Application
 import play.api.i18n.{Messages, MessagesApi}

--- a/test/unit/connectors/BindingTariffClassificationConnectorSpec.scala
+++ b/test/unit/connectors/BindingTariffClassificationConnectorSpec.scala
@@ -16,6 +16,7 @@
 
 package connectors
 
+import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.client.WireMock._
 import models._
 import models.requests.NewEventRequest
@@ -42,7 +43,7 @@ class BindingTariffClassificationConnectorSpec extends ConnectorTest {
       val response     = oCase.btiCaseExample
       val responseJSON = Json.toJson(response).toString()
 
-      stubFor(
+      WireMock.stubFor(
         post(urlEqualTo("/cases"))
           .withRequestBody(equalToJson(requestJSON))
           .willReturn(
@@ -54,7 +55,7 @@ class BindingTariffClassificationConnectorSpec extends ConnectorTest {
 
       await(connector.createCase(request)(withHeaderCarrier("custom token"))) shouldBe response
 
-      verify(
+      WireMock.verify(
         postRequestedFor(urlEqualTo("/cases"))
           .withHeader("X-Api-Token", equalTo("custom token"))
       )
@@ -63,7 +64,7 @@ class BindingTariffClassificationConnectorSpec extends ConnectorTest {
     "Find valid case with x-api-token" in {
       val responseJSON = Json.toJson(oCase.btiCaseExample).toString()
 
-      stubFor(
+      WireMock.stubFor(
         get(urlEqualTo("/cases/id"))
           .willReturn(
             aResponse()
@@ -76,14 +77,14 @@ class BindingTariffClassificationConnectorSpec extends ConnectorTest {
         connector.findCase("id")(withHeaderCarrier(appConfig.apiToken))
       ) shouldBe Some(oCase.btiCaseExample)
 
-      verify(
+      WireMock.verify(
         getRequestedFor(urlEqualTo("/cases/id"))
           .withHeader("X-Api-Token", equalTo(appConfig.apiToken))
       )
     }
 
     "propagate errors with x-api-token" in {
-      stubFor(
+      WireMock.stubFor(
         post(urlEqualTo("/cases"))
           .willReturn(
             aResponse()
@@ -95,7 +96,7 @@ class BindingTariffClassificationConnectorSpec extends ConnectorTest {
         await(connector.createCase(request)(withHeaderCarrier(appConfig.apiToken)))
       }
 
-      verify(
+      WireMock.verify(
         postRequestedFor(urlEqualTo("/cases"))
           .withHeader("X-Api-Token", equalTo(appConfig.apiToken))
       )
@@ -105,7 +106,7 @@ class BindingTariffClassificationConnectorSpec extends ConnectorTest {
       val response     = oCase.btiCaseExample
       val responseJSON = Json.toJson(response).toString()
 
-      stubFor(
+      WireMock.stubFor(
         post(urlEqualTo("/cases"))
           .withRequestBody(equalToJson(requestJSON))
           .willReturn(
@@ -117,7 +118,7 @@ class BindingTariffClassificationConnectorSpec extends ConnectorTest {
 
       await(connector.createCase(request)(hc)) shouldBe response
 
-      verify(
+      WireMock.verify(
         postRequestedFor(urlEqualTo("/cases"))
           .withHeader("X-Api-Token", equalTo(appConfig.apiToken))
       )
@@ -126,7 +127,7 @@ class BindingTariffClassificationConnectorSpec extends ConnectorTest {
     "Find valid case without x-api-token" in {
       val responseJSON = Json.toJson(oCase.btiCaseExample).toString()
 
-      stubFor(
+      WireMock.stubFor(
         get(urlEqualTo("/cases/id"))
           .willReturn(
             aResponse()
@@ -137,14 +138,14 @@ class BindingTariffClassificationConnectorSpec extends ConnectorTest {
 
       await(connector.findCase("id")(hc)) shouldBe Some(oCase.btiCaseExample)
 
-      verify(
+      WireMock.verify(
         getRequestedFor(urlEqualTo("/cases/id"))
           .withHeader("X-Api-Token", equalTo(appConfig.apiToken))
       )
     }
 
     "propagate errors without x-api-token" in {
-      stubFor(
+      WireMock.stubFor(
         post(urlEqualTo("/cases"))
           .willReturn(
             aResponse()
@@ -156,7 +157,7 @@ class BindingTariffClassificationConnectorSpec extends ConnectorTest {
         await(connector.createCase(request)(hc))
       }
 
-      verify(
+      WireMock.verify(
         postRequestedFor(urlEqualTo("/cases"))
           .withHeader("X-Api-Token", equalTo(appConfig.apiToken))
       )
@@ -168,7 +169,7 @@ class BindingTariffClassificationConnectorSpec extends ConnectorTest {
       val caseExample = oCase.btiCaseExample
       val url         = s"/cases/${caseExample.reference}"
 
-      stubFor(
+      WireMock.stubFor(
         put(urlEqualTo(url))
           .willReturn(
             aResponse()
@@ -181,7 +182,7 @@ class BindingTariffClassificationConnectorSpec extends ConnectorTest {
         connector.putCase(caseExample)(withHeaderCarrier(appConfig.apiToken))
       ) shouldBe caseExample
 
-      verify(
+      WireMock.verify(
         putRequestedFor(urlEqualTo(url))
           .withHeader("X-Api-Token", equalTo(appConfig.apiToken))
       )
@@ -191,7 +192,7 @@ class BindingTariffClassificationConnectorSpec extends ConnectorTest {
       val caseExample = oCase.btiCaseExample
       val url         = s"/cases/${caseExample.reference}"
 
-      stubFor(
+      WireMock.stubFor(
         put(urlEqualTo(url))
           .willReturn(
             aResponse()
@@ -205,7 +206,7 @@ class BindingTariffClassificationConnectorSpec extends ConnectorTest {
         )
       }
 
-      verify(
+      WireMock.verify(
         putRequestedFor(urlEqualTo(url))
           .withHeader("X-Api-Token", equalTo(appConfig.apiToken))
       )
@@ -215,7 +216,7 @@ class BindingTariffClassificationConnectorSpec extends ConnectorTest {
       val caseExample = oCase.btiCaseExample
       val url         = s"/cases/${caseExample.reference}"
 
-      stubFor(
+      WireMock.stubFor(
         put(urlEqualTo(url))
           .willReturn(
             aResponse()
@@ -229,7 +230,7 @@ class BindingTariffClassificationConnectorSpec extends ConnectorTest {
         )
       }
 
-      verify(
+      WireMock.verify(
         putRequestedFor(urlEqualTo(url))
           .withHeader("X-Api-Token", equalTo(appConfig.apiToken))
       )
@@ -241,7 +242,7 @@ class BindingTariffClassificationConnectorSpec extends ConnectorTest {
       val caseRef = oCase.btiCaseExample.reference
       val url     = s"/cases/$caseRef"
 
-      stubFor(
+      WireMock.stubFor(
         post(urlEqualTo(url))
           .willReturn(
             aResponse()
@@ -254,7 +255,7 @@ class BindingTariffClassificationConnectorSpec extends ConnectorTest {
         connector.updateCase(caseRef, CaseUpdate())(withHeaderCarrier(appConfig.apiToken))
       ) shouldBe Some(oCase.btiCaseExample)
 
-      verify(
+      WireMock.verify(
         postRequestedFor(urlEqualTo(url))
           .withHeader("X-Api-Token", equalTo(appConfig.apiToken))
       )
@@ -263,7 +264,7 @@ class BindingTariffClassificationConnectorSpec extends ConnectorTest {
     "Return empty response for missing case" in {
       val url = s"/cases/foo"
 
-      stubFor(
+      WireMock.stubFor(
         post(urlEqualTo(url))
           .willReturn(
             aResponse()
@@ -275,7 +276,7 @@ class BindingTariffClassificationConnectorSpec extends ConnectorTest {
         connector.updateCase("foo", CaseUpdate())(withHeaderCarrier(appConfig.apiToken))
       ) shouldBe None
 
-      verify(
+      WireMock.verify(
         postRequestedFor(urlEqualTo(url))
           .withHeader("X-Api-Token", equalTo(appConfig.apiToken))
       )
@@ -284,7 +285,7 @@ class BindingTariffClassificationConnectorSpec extends ConnectorTest {
     "Propagate errors" in {
       val url = "/cases/foo"
 
-      stubFor(
+      WireMock.stubFor(
         post(urlEqualTo(url))
           .willReturn(
             aResponse()
@@ -298,7 +299,7 @@ class BindingTariffClassificationConnectorSpec extends ConnectorTest {
         )
       }
 
-      verify(
+      WireMock.verify(
         postRequestedFor(urlEqualTo(url))
           .withHeader("X-Api-Token", equalTo(appConfig.apiToken))
       )
@@ -313,7 +314,7 @@ class BindingTariffClassificationConnectorSpec extends ConnectorTest {
       val url =
         "/cases?sort_by=created-date&sort_direction=desc&page=2&page_size=50&application_type=BTI&migrated=false"
 
-      stubFor(
+      WireMock.stubFor(
         get(urlEqualTo(url))
           .willReturn(
             aResponse()
@@ -326,7 +327,7 @@ class BindingTariffClassificationConnectorSpec extends ConnectorTest {
         connector.allCases(SearchPagination(page, pageSize), Sort())(withHeaderCarrier(appConfig.apiToken))
       ) shouldBe Paged.empty[Case]
 
-      verify(
+      WireMock.verify(
         getRequestedFor(urlEqualTo(url))
           .withHeader("X-Api-Token", equalTo(appConfig.apiToken))
       )
@@ -337,7 +338,7 @@ class BindingTariffClassificationConnectorSpec extends ConnectorTest {
       val url =
         "/cases?sort_by=created-date&sort_direction=desc&page=2&page_size=50&application_type=BTI&migrated=false"
 
-      stubFor(
+      WireMock.stubFor(
         get(urlEqualTo(url))
           .willReturn(
             aResponse()
@@ -350,7 +351,7 @@ class BindingTariffClassificationConnectorSpec extends ConnectorTest {
         connector.allCases(SearchPagination(page, pageSize), Sort())(withHeaderCarrier(appConfig.apiToken))
       ) shouldBe Paged(Seq(oCase.btiCaseExample))
 
-      verify(
+      WireMock.verify(
         getRequestedFor(urlEqualTo(url))
           .withHeader("X-Api-Token", equalTo(appConfig.apiToken))
       )
@@ -361,7 +362,7 @@ class BindingTariffClassificationConnectorSpec extends ConnectorTest {
       val url =
         "/cases?sort_by=created-date&sort_direction=desc&page=1&page_size=50&application_type=BTI&migrated=false"
 
-      stubFor(
+      WireMock.stubFor(
         get(urlEqualTo(url))
           .willReturn(
             aResponse()
@@ -375,7 +376,7 @@ class BindingTariffClassificationConnectorSpec extends ConnectorTest {
         )
       }
 
-      verify(
+      WireMock.verify(
         getRequestedFor(urlEqualTo(url))
           .withHeader("X-Api-Token", equalTo(appConfig.apiToken))
       )
@@ -388,7 +389,7 @@ class BindingTariffClassificationConnectorSpec extends ConnectorTest {
       val url =
         "/cases?eori=eori1234567&status=NEW,OPEN&sort_by=created-date&sort_direction=desc&page=2&page_size=50&migrated=false"
 
-      stubFor(
+      WireMock.stubFor(
         get(urlEqualTo(url))
           .willReturn(
             aResponse()
@@ -406,7 +407,7 @@ class BindingTariffClassificationConnectorSpec extends ConnectorTest {
         )(withHeaderCarrier(appConfig.apiToken))
       ) shouldBe Paged.empty[Case]
 
-      verify(
+      WireMock.verify(
         getRequestedFor(urlEqualTo(url))
           .withHeader("X-Api-Token", equalTo(appConfig.apiToken))
       )
@@ -416,7 +417,7 @@ class BindingTariffClassificationConnectorSpec extends ConnectorTest {
       val url =
         "/cases?eori=eori1234567&status=NEW,OPEN&sort_by=created-date&sort_direction=desc&page=2&page_size=50&migrated=false"
 
-      stubFor(
+      WireMock.stubFor(
         get(urlEqualTo(url))
           .willReturn(
             aResponse()
@@ -434,7 +435,7 @@ class BindingTariffClassificationConnectorSpec extends ConnectorTest {
         )(withHeaderCarrier(appConfig.apiToken))
       ) shouldBe Paged(Seq(oCase.btiCaseExample))
 
-      verify(
+      WireMock.verify(
         getRequestedFor(urlEqualTo(url))
           .withHeader("X-Api-Token", equalTo(appConfig.apiToken))
       )
@@ -444,7 +445,7 @@ class BindingTariffClassificationConnectorSpec extends ConnectorTest {
       val url =
         "/cases?eori=eori1234567&status=NEW&sort_by=created-date&sort_direction=desc&page=1&page_size=2147483647&migrated=false"
 
-      stubFor(
+      WireMock.stubFor(
         get(urlEqualTo(url))
           .willReturn(
             aResponse()
@@ -463,7 +464,7 @@ class BindingTariffClassificationConnectorSpec extends ConnectorTest {
         )
       }
 
-      verify(
+      WireMock.verify(
         getRequestedFor(urlEqualTo(url))
           .withHeader("X-Api-Token", equalTo(appConfig.apiToken))
       )
@@ -485,7 +486,7 @@ class BindingTariffClassificationConnectorSpec extends ConnectorTest {
       val requestJson       = Json.toJson(validEventRequest).toString()
       val responseJson      = Json.toJson(validEvent).toString()
 
-      stubFor(
+      WireMock.stubFor(
         post(urlEqualTo(s"/cases/$ref/events"))
           .withRequestBody(equalToJson(requestJson))
           .willReturn(
@@ -497,7 +498,7 @@ class BindingTariffClassificationConnectorSpec extends ConnectorTest {
 
       await(connector.createEvent(validCase, validEventRequest)) shouldBe validEvent
 
-      verify(
+      WireMock.verify(
         postRequestedFor(urlEqualTo(s"/cases/$ref/events"))
           .withHeader("X-Api-Token", equalTo(fakeAuthToken))
       )
@@ -509,7 +510,7 @@ class BindingTariffClassificationConnectorSpec extends ConnectorTest {
       val validEventRequest = eventRequest
       val requestJson       = Json.toJson(validEventRequest).toString()
 
-      stubFor(
+      WireMock.stubFor(
         post(urlEqualTo(s"/cases/$ref/events"))
           .withRequestBody(equalToJson(requestJson))
           .willReturn(
@@ -522,7 +523,7 @@ class BindingTariffClassificationConnectorSpec extends ConnectorTest {
         await(connector.createEvent(validCase, validEventRequest))
       }
 
-      verify(
+      WireMock.verify(
         postRequestedFor(urlEqualTo(s"/cases/$ref/events"))
           .withHeader("X-Api-Token", equalTo(fakeAuthToken))
       )

--- a/test/unit/connectors/BindingTariffFilestoreConnectorSpec.scala
+++ b/test/unit/connectors/BindingTariffFilestoreConnectorSpec.scala
@@ -16,22 +16,19 @@
 
 package connectors
 
-import java.nio.charset.StandardCharsets
-
 import akka.util.ByteString
+import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.client.WireMock._
-import models.response.FilestoreResponse
+import models.requests.FileStoreInitiateRequest
+import models.response.{FileStoreInitiateResponse, FilestoreResponse, UpscanFormTemplate}
 import models.{Attachment, FileAttachment}
 import org.mockito.BDDMockito.given
 import play.api.http.Status
 import uk.gov.hmrc.http.HeaderCarrier
-
-import scala.concurrent.ExecutionContext.Implicits.global
-import models.requests.FileStoreInitiateRequest
-import models.response.FileStoreInitiateResponse
-import models.response.UpscanFormTemplate
 import unit.base.WireMockObject.wireMockUrl
 
+import java.nio.charset.StandardCharsets
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
 class BindingTariffFilestoreConnectorSpec extends ConnectorTest {
@@ -45,7 +42,7 @@ class BindingTariffFilestoreConnectorSpec extends ConnectorTest {
   "Connector" should {
 
     "Initiate" in {
-      stubFor(
+      WireMock.stubFor(
         post("/file/initiate")
           .willReturn(
             aResponse()
@@ -65,14 +62,14 @@ class BindingTariffFilestoreConnectorSpec extends ConnectorTest {
         )
       )
 
-      verify(
+      WireMock.verify(
         postRequestedFor(urlEqualTo("/file/initiate"))
           .withHeader("X-Api-Token", equalTo(mockConfig.apiToken))
       )
     }
 
     "Get" in {
-      stubFor(
+      WireMock.stubFor(
         get("/file/id")
           .willReturn(
             aResponse()
@@ -89,7 +86,7 @@ class BindingTariffFilestoreConnectorSpec extends ConnectorTest {
         mimeType = "text/plain"
       )
 
-      verify(
+      WireMock.verify(
         getRequestedFor(urlEqualTo("/file/id"))
           .withHeader("X-Api-Token", equalTo(appConfig.apiToken))
       )
@@ -100,14 +97,14 @@ class BindingTariffFilestoreConnectorSpec extends ConnectorTest {
         val att = mock[Attachment]
         given(att.id) willReturn "id"
 
-        stubFor(
+        WireMock.stubFor(
           get("/file/id")
             .willReturn(aResponse().withStatus(Status.NOT_FOUND))
         )
 
         await(connector.get(att)(withHeaderCarrier(appConfig.apiToken))) shouldBe None
 
-        verify(
+        WireMock.verify(
           getRequestedFor(urlEqualTo("/file/id"))
             .withHeader("X-Api-Token", equalTo(appConfig.apiToken))
         )
@@ -117,7 +114,7 @@ class BindingTariffFilestoreConnectorSpec extends ConnectorTest {
         val att = mock[Attachment]
         given(att.id) willReturn "id"
 
-        stubFor(
+        WireMock.stubFor(
           get("/file/id")
             .willReturn(
               aResponse()
@@ -138,7 +135,7 @@ class BindingTariffFilestoreConnectorSpec extends ConnectorTest {
           )
         )
 
-        verify(
+        WireMock.verify(
           getRequestedFor(urlEqualTo("/file/id"))
             .withHeader("X-Api-Token", equalTo(appConfig.apiToken))
         )
@@ -146,7 +143,7 @@ class BindingTariffFilestoreConnectorSpec extends ConnectorTest {
     }
 
     "Publish" in {
-      stubFor(
+      WireMock.stubFor(
         post("/file/id/publish")
           .willReturn(
             aResponse()
@@ -163,14 +160,14 @@ class BindingTariffFilestoreConnectorSpec extends ConnectorTest {
         mimeType = "text/plain"
       )
 
-      verify(
+      WireMock.verify(
         getRequestedFor(urlEqualTo("/file/id"))
           .withHeader("X-Api-Token", equalTo(appConfig.apiToken))
       )
     }
 
     "Get FileMetadata" in {
-      stubFor(
+      WireMock.stubFor(
         get("/file?id=id1&id=id2")
           .willReturn(
             aResponse()
@@ -188,7 +185,7 @@ class BindingTariffFilestoreConnectorSpec extends ConnectorTest {
         FilestoreResponse(id = "id2", fileName = "file-name2.txt", mimeType = "text/plain")
       )
 
-      verify(
+      WireMock.verify(
         getRequestedFor(urlEqualTo("/file?id=id1&id=id2"))
           .withHeader("X-Api-Token", equalTo(appConfig.apiToken))
       )
@@ -199,7 +196,7 @@ class BindingTariffFilestoreConnectorSpec extends ConnectorTest {
     }
 
     "Upload Application PDF" in {
-      stubFor(
+      WireMock.stubFor(
         post("/file")
           .willReturn(
             aResponse()
@@ -211,7 +208,7 @@ class BindingTariffFilestoreConnectorSpec extends ConnectorTest {
       await(connector.uploadApplicationPdf("ref", "content".getBytes(StandardCharsets.UTF_8))) shouldBe
         FilestoreResponse("id", "file-name.txt", "text/plain")
 
-      verify(
+      WireMock.verify(
         postRequestedFor(urlEqualTo("/file"))
           .withHeader("X-Api-Token", equalTo(mockConfig.apiToken))
       )
@@ -220,7 +217,7 @@ class BindingTariffFilestoreConnectorSpec extends ConnectorTest {
     "Download file from a URL" in {
       val content = "content".getBytes(StandardCharsets.UTF_8)
 
-      stubFor(
+      WireMock.stubFor(
         get(urlEqualTo("/digital-tariffs-local/a1e8057e-fbbc-47a8-a8b4-78d9f015c253"))
           .willReturn(
             aResponse()
@@ -243,7 +240,7 @@ class BindingTariffFilestoreConnectorSpec extends ConnectorTest {
 
     "Fail to download file from a URL" in {
 
-      stubFor(
+      WireMock.stubFor(
         get(urlEqualTo("/digital-tariffs-local/717f3a7a-db8e-11e9-8a34-2a2ae2dbcce4"))
           .willReturn(
             aResponse()
@@ -259,7 +256,7 @@ class BindingTariffFilestoreConnectorSpec extends ConnectorTest {
     "Handle 404" when {
       "downloading a file from a URL" in {
 
-        stubFor(
+        WireMock.stubFor(
           get(urlEqualTo("/digital-tariffs-local/c432a56d-e811-474c-a26a-76fc3bcaefe5"))
             .willReturn(
               aResponse()

--- a/test/unit/connectors/EmailConnectorSpec.scala
+++ b/test/unit/connectors/EmailConnectorSpec.scala
@@ -16,6 +16,7 @@
 
 package connectors
 
+import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.client.WireMock._
 import com.github.tomakehurst.wiremock.matching.EqualToJsonPattern
 import models.{ApplicationSubmittedEmail, ApplicationSubmittedParameters}
@@ -33,7 +34,7 @@ class EmailConnectorSpec extends ConnectorTest {
   "Connector 'Send'" should {
 
     "POST Email payload" in {
-      stubFor(
+      WireMock.stubFor(
         post(urlEqualTo("/hmrc/email"))
           .withRequestBody(new EqualToJsonPattern(fromResource("advice_request_email-request.json"), true, false))
           .willReturn(
@@ -44,14 +45,14 @@ class EmailConnectorSpec extends ConnectorTest {
 
       await(connector.send(email)) shouldBe ((): Unit)
 
-      verify(
+      WireMock.verify(
         postRequestedFor(urlEqualTo("/hmrc/email"))
           .withoutHeader("X-Api-Token")
       )
     }
 
     "propagate errors" in {
-      stubFor(
+      WireMock.stubFor(
         post(urlEqualTo("/hmrc/email"))
           .willReturn(
             aResponse()
@@ -63,7 +64,7 @@ class EmailConnectorSpec extends ConnectorTest {
         await(connector.send(email))
       }
 
-      verify(
+      WireMock.verify(
         postRequestedFor(urlEqualTo("/hmrc/email"))
           .withoutHeader("X-Api-Token")
       )

--- a/test/unit/connectors/MongoCacheConnectorSpec.scala
+++ b/test/unit/connectors/MongoCacheConnectorSpec.scala
@@ -18,7 +18,6 @@ package connectors
 
 import generators.Generators
 import org.mockito.ArgumentMatchers.{any, refEq}
-import org.mockito.Mockito.{verify, when}
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks

--- a/test/unit/connectors/PdfGeneratorServiceConnectorSpec.scala
+++ b/test/unit/connectors/PdfGeneratorServiceConnectorSpec.scala
@@ -16,6 +16,7 @@
 
 package connectors
 
+import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.client.WireMock._
 import models.PdfFile
 import play.api.http.Status
@@ -47,7 +48,7 @@ class PdfGeneratorServiceConnectorSpec extends ConnectorTest {
       response.contentType shouldBe "application/pdf"
       response.content     shouldBe expectedContent
 
-      verify(
+      WireMock.verify(
         postRequestedFor(urlEqualTo("/pdf-generator-service/generate"))
           .withoutHeader("X-Api-Token")
       )
@@ -69,7 +70,7 @@ class PdfGeneratorServiceConnectorSpec extends ConnectorTest {
 
       caught.getMessage contains "Error calling PdfGeneratorService"
 
-      verify(
+      WireMock.verify(
         postRequestedFor(urlEqualTo("/pdf-generator-service/generate"))
           .withoutHeader("X-Api-Token")
       )

--- a/test/unit/controllers/AcceptItemInformationListControllerSpec.scala
+++ b/test/unit/controllers/AcceptItemInformationListControllerSpec.scala
@@ -20,6 +20,8 @@ import controllers.actions._
 import play.api.test.Helpers._
 import views.html.acceptItemInformationList
 
+import scala.concurrent.ExecutionContext.Implicits.global
+
 class AcceptItemInformationListControllerSpec extends ControllerSpecBase {
 
   val acceptItemInformationListView: acceptItemInformationList =

--- a/test/unit/controllers/BeforeYouStartControllerSpec.scala
+++ b/test/unit/controllers/BeforeYouStartControllerSpec.scala
@@ -20,7 +20,6 @@ import connectors.DataCacheConnector
 import controllers.actions._
 import org.mockito.ArgumentMatchers._
 import org.mockito.BDDMockito.given
-import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
 import play.api.mvc.AnyContentAsEmpty
 import play.api.test.FakeRequest

--- a/test/unit/controllers/CheckYourAnswersControllerSpec.scala
+++ b/test/unit/controllers/CheckYourAnswersControllerSpec.scala
@@ -23,7 +23,6 @@ import mapper.CaseRequestMapper
 import models._
 import navigation.FakeNavigator
 import org.mockito.ArgumentMatchers.{any, refEq}
-import org.mockito.Mockito._
 import org.scalatest.BeforeAndAfterEach
 import pages.{CheckYourAnswersPage, MakeFileConfidentialPage, UploadSupportingMaterialMultiplePage}
 import play.api.http.Status
@@ -178,7 +177,7 @@ class CheckYourAnswersControllerSpec extends ControllerSpecBase with BeforeAndAf
 
     caught shouldBe error
 
-    verify(casesService, never()).addCaseCreatedEvent(any[Case], any[Operator])(any[HeaderCarrier])
+    verify(casesService, never).addCaseCreatedEvent(any[Case], any[Operator])(any[HeaderCarrier])
   }
 
   "send the expected explicit audit events when the ATAR application has been submitted successfully" in {

--- a/test/unit/controllers/ConfirmationControllerSpec.scala
+++ b/test/unit/controllers/ConfirmationControllerSpec.scala
@@ -21,7 +21,6 @@ import connectors.DataCacheConnector
 import controllers.actions._
 import models.{Confirmation, oCase}
 import org.mockito.BDDMockito.given
-import org.mockito.Mockito._
 import pages.{ConfirmationPage, PdfViewPage}
 import play.api.test.Helpers._
 import service.{BTAUserService, CountriesService, PdfService}
@@ -107,11 +106,11 @@ class ConfirmationControllerSpec extends ControllerSpecBase {
     )
 
     "redirect to an error page" when {
+      given(cache.remove(cacheMap)).willReturn(Future.successful(true))
       errorScenarios foreach { data =>
         s"there is an issue calling ${data._1}" in {
           val fakeRequest = fakeRequestWithNotOptionalEoriAndCache
 
-          given(cache.remove(cacheMap)).willReturn(Future.successful(true))
           given(cacheMap.getEntry[Confirmation](ConfirmationPage.toString))
             .willReturn(Some(Confirmation("ref", "eori", "marisa@example.test")))
           given(cacheMap.getEntry[PdfViewModel](PdfViewPage.toString)).willReturn(Some(pdfViewModel))

--- a/test/unit/controllers/SignOutControllerSpec.scala
+++ b/test/unit/controllers/SignOutControllerSpec.scala
@@ -38,7 +38,7 @@ class SignOutControllerSpec extends ControllerSpecBase with BeforeAndAfterEach {
   override protected def beforeEach(): Unit = {
     super.beforeEach()
 
-    Mockito.reset(dataCache, btaUserService)
+    reset(dataCache, btaUserService)
   }
 
   private def controller = new SignOutController(

--- a/test/unit/controllers/actions/DataRetrievalActionSpec.scala
+++ b/test/unit/controllers/actions/DataRetrievalActionSpec.scala
@@ -19,9 +19,8 @@ package controllers.actions
 import base.SpecBase
 import connectors.DataCacheConnector
 import models.requests.{IdentifierRequest, OptionalDataRequest}
-import org.mockito.Mockito._
+import org.mockito.MockitoSugar
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatestplus.mockito.MockitoSugar
 import uk.gov.hmrc.http.cache.client.CacheMap
 
 import scala.concurrent.ExecutionContext.Implicits.global

--- a/test/unit/controllers/behaviours/AnswerCachingControllerBehaviours.scala
+++ b/test/unit/controllers/behaviours/AnswerCachingControllerBehaviours.scala
@@ -17,16 +17,16 @@
 package controllers
 package behaviours
 
-import controllers.actions.{DataRetrievalAction, FakeDataRetrievalAction}
+import controllers.actions.{DataRetrievalAction, DataRetrievalActionImpl, FakeDataRetrievalAction}
 import controllers.routes
-import models.NormalMode
+import models.{NormalMode, UserAnswers}
 import play.api.data.Form
 import play.api.libs.json.{Format, JsValue, Json}
 import play.api.mvc.{Call, Request}
 import play.api.test.Helpers._
 import uk.gov.hmrc.http.cache.client.CacheMap
-import models.UserAnswers
-import controllers.actions.DataRetrievalActionImpl
+
+import scala.concurrent.ExecutionContext.Implicits.global
 
 trait AccumulatingEditingControllerBehaviours extends AccumulatingCachingControllerBehaviours {
   self: ControllerSpecBase =>

--- a/test/unit/filters/AllowListFilterSpec.scala
+++ b/test/unit/filters/AllowListFilterSpec.scala
@@ -21,7 +21,7 @@ import com.typesafe.config.ConfigException
 import generators.Generators
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.Gen
-import org.scalatestplus.mockito.MockitoSugar
+import org.mockito.MockitoSugar
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import play.api.Configuration
 import play.api.mvc.Call

--- a/test/unit/metrics/HasMetricsSpec.scala
+++ b/test/unit/metrics/HasMetricsSpec.scala
@@ -18,16 +18,15 @@ package metrics
 
 import com.codahale.metrics.Timer
 import com.kenshoo.play.metrics.Metrics
-import org.mockito.Mockito
-import org.mockito.Mockito._
 import org.mockito.ArgumentMatchers._
+import org.mockito.{Mockito, MockitoSugar}
+import org.scalatest.compatible.Assertion
 import org.scalatest.matchers.must.Matchers
 import org.scalatest.wordspec.AsyncWordSpecLike
 import org.scalatest.{BeforeAndAfterAll, OptionValues}
-import org.scalatest.compatible.Assertion
-import org.scalatestplus.mockito.MockitoSugar
 import play.api.mvc.{MessagesAbstractController, Results}
 import play.api.test.{FakeRequest, Helpers}
+
 import scala.concurrent.Future
 
 class HasMetricsSpec

--- a/test/unit/service/BTAUserServiceSpec.scala
+++ b/test/unit/service/BTAUserServiceSpec.scala
@@ -18,7 +18,6 @@ package unit.service
 
 import base.SpecBase
 import connectors.DataCacheConnector
-import org.mockito.Mockito.{reset, times, verify, when}
 import play.api.libs.json.Json
 import service.BTAUserService
 import uk.gov.hmrc.http.cache.client.CacheMap

--- a/test/unit/service/CasesServiceSpec.scala
+++ b/test/unit/service/CasesServiceSpec.scala
@@ -28,6 +28,7 @@ import org.mockito.Mockito._
 import play.api.libs.json.Writes
 import uk.gov.hmrc.http.HeaderCarrier
 
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
 class CasesServiceSpec extends SpecBase {

--- a/test/unit/service/CasesServiceSpec.scala
+++ b/test/unit/service/CasesServiceSpec.scala
@@ -21,7 +21,7 @@ import connectors.{BindingTariffClassificationConnector, EmailConnector}
 import models.CaseStatus.CaseStatus
 import models._
 import models.requests.NewEventRequest
-import org.mockito.ArgumentCaptor
+import org.mockito.{ArgumentCaptor, Mockito}
 import org.mockito.ArgumentMatchers._
 import org.mockito.BDDMockito.given
 import org.mockito.Mockito._
@@ -177,7 +177,7 @@ class CasesServiceSpec extends SpecBase {
       }
 
       caught shouldBe exception
-      verify(caseConnector, never()).createEvent(refEq(existingCase), any[NewEventRequest])(any[HeaderCarrier])
+      verify(caseConnector, never).createEvent(refEq(existingCase), any[NewEventRequest])(any[HeaderCarrier])
     }
 
     def theEventCreatedFor(connector: BindingTariffClassificationConnector, c: Case): NewEventRequest = {

--- a/test/unit/service/FileServiceSpec.scala
+++ b/test/unit/service/FileServiceSpec.scala
@@ -16,14 +16,14 @@
 
 package service
 
-import java.io.File
-import java.nio.file.Files
-
+import akka.stream.scaladsl.Source
+import akka.util.ByteString
 import base.SpecBase
 import config.FrontendAppConfig
 import connectors.BindingTariffFilestoreConnector
 import models._
-import models.response.FilestoreResponse
+import models.requests.FileStoreInitiateRequest
+import models.response.{FileStoreInitiateResponse, FilestoreResponse, UpscanFormTemplate}
 import org.mockito.ArgumentMatchers._
 import org.mockito.BDDMockito.given
 import org.mockito.Mockito.reset
@@ -32,12 +32,10 @@ import play.api.mvc.MultipartFormData
 import play.api.mvc.MultipartFormData.FilePart
 import uk.gov.hmrc.http.HeaderCarrier
 
+import java.io.File
+import java.nio.file.Files
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future.{failed, successful}
-import models.requests.FileStoreInitiateRequest
-import models.response.FileStoreInitiateResponse
-import models.response.UpscanFormTemplate
-import akka.util.ByteString
-import akka.stream.scaladsl.Source
 
 class FileServiceSpec extends SpecBase {
 

--- a/test/unit/workers/MigrationWorkerSpec.scala
+++ b/test/unit/workers/MigrationWorkerSpec.scala
@@ -20,9 +20,8 @@ import com.kenshoo.play.metrics.Metrics
 import models._
 import org.mockito.ArgumentMatchers._
 import org.mockito.BDDMockito._
-import org.mockito.Mockito.verify
+import org.mockito.MockitoSugar
 import org.scalatest.BeforeAndAfterAll
-import org.scalatestplus.mockito.MockitoSugar
 import play.api.inject.bind
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test.Helpers

--- a/test/viewmodels/DashboardSpec.scala
+++ b/test/viewmodels/DashboardSpec.scala
@@ -19,8 +19,7 @@ package viewmodels
 import models.SortDirection.{ASCENDING, DESCENDING}
 import models.SortField.{CREATED_DATE, GOODS_NAME, REFERENCE}
 import models.{Paged, SearchPagination, Sort, oCase}
-import org.mockito.Mockito.when
-import org.scalatestplus.mockito.MockitoSugar
+import org.mockito.MockitoSugar
 import play.api.mvc.Request
 import unit.utils.UnitSpec
 


### PR DESCRIPTION
### DDCE-3678: play-frontend-hmrc upgrade to remove any dependency on url-builder

Upgraded play-frontend-hmrc from 3.32.0-play-28 to version 6.4.0-play-28 and checked for uses of url-builder.
Updated dependencies
Checked for any layout changes and ran acceptance tests