### PR TITLE
DDCE-6601: Ensure File Name Persistence After Re-uploading Documents on /upload-documents

### DIFF
--- a/app/audit/AuditService.scala
+++ b/app/audit/AuditService.scala
@@ -16,7 +16,7 @@
 
 package audit
 
-import audit.AuditPayloadType._
+import audit.AuditPayloadType.*
 import models.{Application, Case}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.audit.DefaultAuditConnector

--- a/app/config/Module.scala
+++ b/app/config/Module.scala
@@ -16,7 +16,7 @@
 
 package config
 
-import controllers.actions._
+import controllers.actions.*
 import org.apache.fop.apps.FopFactory
 import play.api.inject.{Binding, Module => PlayModule}
 import play.api.{Configuration, Environment}

--- a/app/connectors/BindingTariffFilestoreConnector.scala
+++ b/app/connectors/BindingTariffFilestoreConnector.scala
@@ -28,7 +28,7 @@ import org.apache.pekko.util.ByteString
 import play.api.libs.json.Json
 import play.api.mvc.MultipartFormData
 import play.api.mvc.MultipartFormData.{DataPart, FilePart}
-import uk.gov.hmrc.http.HttpReads.Implicits._
+import uk.gov.hmrc.http.HttpReads.Implicits.*
 import uk.gov.hmrc.http.client.HttpClientV2
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse, StringContextOps}
 import play.api.libs.ws.writeableOf_JsValue

--- a/app/connectors/EmailConnector.scala
+++ b/app/connectors/EmailConnector.scala
@@ -21,7 +21,7 @@ import config.FrontendAppConfig
 import metrics.HasMetrics
 import models.Email
 import play.api.libs.json.{Json, Writes}
-import uk.gov.hmrc.http.HttpReads.Implicits._
+import uk.gov.hmrc.http.HttpReads.Implicits.*
 import uk.gov.hmrc.http.client.HttpClientV2
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse, StringContextOps}
 import play.api.libs.ws.writeableOf_JsValue

--- a/app/controllers/AddConfidentialInformationController.scala
+++ b/app/controllers/AddConfidentialInformationController.scala
@@ -17,7 +17,7 @@
 package controllers
 
 import config.FrontendAppConfig
-import controllers.actions._
+import controllers.actions.*
 import forms.AddConfidentialInformationFormProvider
 import models.Mode
 import models.requests.DataRequest

--- a/app/controllers/CommodityCodeBestMatchController.scala
+++ b/app/controllers/CommodityCodeBestMatchController.scala
@@ -17,7 +17,7 @@
 package controllers
 
 import config.FrontendAppConfig
-import controllers.actions._
+import controllers.actions.*
 import forms.CommodityCodeBestMatchFormProvider
 import models.Mode
 import models.requests.DataRequest

--- a/app/controllers/HowWeContactYouController.scala
+++ b/app/controllers/HowWeContactYouController.scala
@@ -16,7 +16,7 @@
 
 package controllers
 
-import controllers.actions._
+import controllers.actions.*
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController

--- a/app/controllers/MakeFileConfidentialController.scala
+++ b/app/controllers/MakeFileConfidentialController.scala
@@ -54,17 +54,15 @@ class MakeFileConfidentialController @Inject() (
     request: DataRequest[?]
   ): HtmlFormat.Appendable = {
     val fileId: String = request.userAnswers.get(UploadSupportingMaterialMultiplePage).map(_.last.id).get
-      makeFileConfidentialView(appConfig, preparedForm, submitAction, mode, fileId)
+    makeFileConfidentialView(appConfig, preparedForm, submitAction, mode, fileId)
   }
 
   override def onPageLoad(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData) {
-    implicit request:DataRequest[?] =>
-      val files = request.userAnswers.get(UploadSupportingMaterialMultiplePage)
-      if(files.get.isEmpty){
-        val fileId = request.id.toString
-        Redirect(routes.UploadSupportingMaterialMultipleController.onPageLoad(Some(fileId), mode))
-      } else {
-        Ok(renderView(form, submitAction(mode), mode))
+    implicit request: DataRequest[?] =>
+      request.userAnswers.get(UploadSupportingMaterialMultiplePage) match {
+        case Some(files) if files.nonEmpty => Ok(renderView(form, submitAction(mode), mode))
+        case _ =>
+          Redirect(routes.UploadSupportingMaterialMultipleController.onPageLoad(Some(request.id.toString), mode))
       }
   }
 

--- a/app/controllers/MakeFileConfidentialController.scala
+++ b/app/controllers/MakeFileConfidentialController.scala
@@ -17,14 +17,14 @@
 package controllers
 
 import config.FrontendAppConfig
-import controllers.actions._
+import controllers.actions.*
 import forms.MakeFileConfidentialFormProvider
-import models.Mode
 import models.requests.DataRequest
+import models.{FileAttachment, Mode}
 import navigation.Navigator
-import pages._
+import pages.*
 import play.api.data.Form
-import play.api.mvc.{Call, MessagesControllerComponents}
+import play.api.mvc.{Action, AnyContent, Call, MessagesControllerComponents}
 import play.twirl.api.HtmlFormat
 import service.DataCacheService
 import views.html.makeFileConfidential
@@ -54,7 +54,18 @@ class MakeFileConfidentialController @Inject() (
     request: DataRequest[?]
   ): HtmlFormat.Appendable = {
     val fileId: String = request.userAnswers.get(UploadSupportingMaterialMultiplePage).map(_.last.id).get
-    makeFileConfidentialView(appConfig, preparedForm, submitAction, mode, fileId)
+      makeFileConfidentialView(appConfig, preparedForm, submitAction, mode, fileId)
+  }
+
+  override def onPageLoad(mode: Mode): Action[AnyContent] = (identify andThen getData andThen requireData) {
+    implicit request:DataRequest[?] =>
+      val files = request.userAnswers.get(UploadSupportingMaterialMultiplePage)
+      if(files.get.isEmpty){
+        val fileId = request.id.toString
+        Redirect(routes.UploadSupportingMaterialMultipleController.onPageLoad(Some(fileId), mode))
+      } else {
+        Ok(renderView(form, submitAction(mode), mode))
+      }
   }
 
 }

--- a/app/controllers/PreviousBTIRulingController.scala
+++ b/app/controllers/PreviousBTIRulingController.scala
@@ -17,7 +17,7 @@
 package controllers
 
 import config.FrontendAppConfig
-import controllers.actions._
+import controllers.actions.*
 import forms.PreviousBTIRulingFormProvider
 import models.Mode
 import models.requests.DataRequest

--- a/app/controllers/ProvideGoodsNameController.scala
+++ b/app/controllers/ProvideGoodsNameController.scala
@@ -17,7 +17,7 @@
 package controllers
 
 import config.FrontendAppConfig
-import controllers.actions._
+import controllers.actions.*
 import forms.ProvideGoodsNameFormProvider
 import models.Mode
 import models.requests.DataRequest

--- a/app/controllers/SupportingMaterialFileListController.scala
+++ b/app/controllers/SupportingMaterialFileListController.scala
@@ -93,11 +93,12 @@ class SupportingMaterialFileListController @Inject() (
     implicit request =>
       val updatedAnswers = removeFile(fileId, request.userAnswers)
 
-      val onwardRoute = if (updatedAnswers.get(UploadSupportingMaterialMultiplePage).get.isEmpty) {
+      val onwardRoute = if (updatedAnswers.get(UploadSupportingMaterialMultiplePage).forall(_.isEmpty)) {
         routes.AddSupportingDocumentsController.onPageLoad(mode)
       } else {
         routes.SupportingMaterialFileListController.onPageLoad(mode)
       }
+
       dataCacheService
         .save(updatedAnswers.cacheMap)
         .map(_ => Redirect(onwardRoute).flashing(success("supportingMaterialFile.remove.file.success.text")))

--- a/app/controllers/SupportingMaterialFileListController.scala
+++ b/app/controllers/SupportingMaterialFileListController.scala
@@ -24,7 +24,7 @@ import models.{FileAttachment, Mode, UserAnswers}
 import navigation.Navigator
 import pages.*
 import play.api.data.{Form, FormError}
-import play.api.mvc.{Action, AnyContent, Call, MessagesControllerComponents}
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import play.twirl.api.HtmlFormat
 import service.DataCacheService
 import uk.gov.hmrc.play.bootstrap.controller.WithUnsafeDefaultFormBinding

--- a/app/controllers/SupportingMaterialFileListController.scala
+++ b/app/controllers/SupportingMaterialFileListController.scala
@@ -17,18 +17,18 @@
 package controllers
 
 import config.FrontendAppConfig
-import controllers.actions._
+import controllers.actions.*
 import forms.SupportingMaterialFileListFormProvider
 import models.requests.DataRequest
 import models.{FileAttachment, Mode, UserAnswers}
 import navigation.Navigator
-import pages._
+import pages.*
 import play.api.data.{Form, FormError}
-import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import play.api.mvc.{Action, AnyContent, Call, MessagesControllerComponents}
 import play.twirl.api.HtmlFormat
 import service.DataCacheService
 import uk.gov.hmrc.play.bootstrap.controller.WithUnsafeDefaultFormBinding
-import utils.Notification.{success, _}
+import utils.Notification.{success, *}
 import viewmodels.FileView
 import views.html.supportingMaterialFileList
 
@@ -93,12 +93,11 @@ class SupportingMaterialFileListController @Inject() (
     implicit request =>
       val updatedAnswers = removeFile(fileId, request.userAnswers)
 
-      val onwardRoute = if (updatedAnswers.get(AddSupportingDocumentsPage).isEmpty) {
+      val onwardRoute = if (updatedAnswers.get(UploadSupportingMaterialMultiplePage).get.isEmpty) {
         routes.AddSupportingDocumentsController.onPageLoad(mode)
       } else {
         routes.SupportingMaterialFileListController.onPageLoad(mode)
       }
-
       dataCacheService
         .save(updatedAnswers.cacheMap)
         .map(_ => Redirect(onwardRoute).flashing(success("supportingMaterialFile.remove.file.success.text")))

--- a/app/forms/EnterContactDetailsFormProvider.scala
+++ b/app/forms/EnterContactDetailsFormProvider.scala
@@ -19,7 +19,7 @@ package forms
 import forms.mappings.{Constraints, Mappings}
 import models.EnterContactDetails
 import play.api.data.Form
-import play.api.data.Forms._
+import play.api.data.Forms.*
 
 import javax.inject.Inject
 

--- a/app/forms/ProvideBTIReferenceFormProvider.scala
+++ b/app/forms/ProvideBTIReferenceFormProvider.scala
@@ -19,7 +19,7 @@ package forms
 import forms.mappings.Mappings
 import models.BTIReference
 import play.api.data.Form
-import play.api.data.Forms._
+import play.api.data.Forms.*
 
 import javax.inject.Inject
 

--- a/app/forms/RegisteredAddressForEoriFormProvider.scala
+++ b/app/forms/RegisteredAddressForEoriFormProvider.scala
@@ -19,7 +19,7 @@ package forms
 import forms.mappings.Mappings
 import models.RegisteredAddressForEori
 import play.api.data.Form
-import play.api.data.Forms._
+import play.api.data.Forms.*
 
 import javax.inject.Inject
 

--- a/app/forms/mappings/Constraints.scala
+++ b/app/forms/mappings/Constraints.scala
@@ -33,7 +33,7 @@ trait Constraints {
 
   protected def minimumValue[A](minimum: A, errorKey: String)(implicit ev: Ordering[A]): Constraint[A] =
     Constraint { (input: A) =>
-      import ev._
+      import ev.*
 
       if (input >= minimum) {
         Valid
@@ -44,7 +44,7 @@ trait Constraints {
 
   protected def maximumValue[A](maximum: A, errorKey: String)(implicit ev: Ordering[A]): Constraint[A] =
     Constraint { (input: A) =>
-      import ev._
+      import ev.*
 
       if (input <= maximum) {
         Valid
@@ -55,7 +55,7 @@ trait Constraints {
 
   protected def inRange[A](minimum: A, maximum: A, errorKey: String)(implicit ev: Ordering[A]): Constraint[A] =
     Constraint { (input: A) =>
-      import ev._
+      import ev.*
 
       if (input >= minimum && input <= maximum) {
         Valid

--- a/app/mapper/CaseRequestMapper.scala
+++ b/app/mapper/CaseRequestMapper.scala
@@ -18,8 +18,8 @@ package mapper
 
 import com.google.inject.Inject
 import config.FrontendAppConfig
-import models._
-import pages._
+import models.*
+import pages.*
 
 import javax.inject.Singleton
 

--- a/app/metrics/HasMetrics.scala
+++ b/app/metrics/HasMetrics.scala
@@ -17,7 +17,7 @@
 package metrics
 
 import com.codahale.metrics.{MetricRegistry, Timer}
-import play.api.mvc._
+import play.api.mvc.*
 
 import java.util.concurrent.atomic.AtomicBoolean
 import scala.concurrent.{ExecutionContext, Future}

--- a/app/models/BTIReference.scala
+++ b/app/models/BTIReference.scala
@@ -16,7 +16,7 @@
 
 package models
 
-import play.api.libs.json._
+import play.api.libs.json.*
 
 case class BTIReference(reference: String)
 

--- a/app/models/CaseStatus.scala
+++ b/app/models/CaseStatus.scala
@@ -16,7 +16,7 @@
 
 package models
 
-import play.api.libs.json._
+import play.api.libs.json.*
 
 enum CaseStatus {
   case DRAFT, NEW, OPEN, SUPPRESSED, REFERRED, REJECTED, CANCELLED, SUSPENDED, COMPLETED, REVOKED, ANNULLED

--- a/app/models/Country.scala
+++ b/app/models/Country.scala
@@ -17,7 +17,7 @@
 package models
 
 import play.api.i18n.Messages
-import play.api.libs.json._
+import play.api.libs.json.*
 
 case class Country(code: String, countryName: String, alphaTwoCode: String, countrySynonyms: List[String]) {
 

--- a/app/models/Email.scala
+++ b/app/models/Email.scala
@@ -16,7 +16,7 @@
 
 package models
 
-import play.api.libs.json._
+import play.api.libs.json.*
 import utils.Union
 
 sealed trait Email[T] {

--- a/app/models/EnterContactDetails.scala
+++ b/app/models/EnterContactDetails.scala
@@ -16,7 +16,7 @@
 
 package models
 
-import play.api.libs.json._
+import play.api.libs.json.*
 
 case class EnterContactDetails(name: String, email: String, phoneNumber: String)
 

--- a/app/models/Enumerable.scala
+++ b/app/models/Enumerable.scala
@@ -16,7 +16,7 @@
 
 package models
 
-import play.api.libs.json._
+import play.api.libs.json.*
 
 trait Enumerable[A] {
 

--- a/app/models/Paged.scala
+++ b/app/models/Paged.scala
@@ -16,7 +16,7 @@
 
 package models
 
-import play.api.libs.json._
+import play.api.libs.json.*
 
 import scala.util.Try
 

--- a/app/models/RegisteredAddressForEori.scala
+++ b/app/models/RegisteredAddressForEori.scala
@@ -16,7 +16,7 @@
 
 package models
 
-import play.api.libs.json._
+import play.api.libs.json.*
 
 case class RegisteredAddressForEori(
   eori: String,

--- a/app/models/ScanStatus.scala
+++ b/app/models/ScanStatus.scala
@@ -16,7 +16,7 @@
 
 package models
 
-import play.api.libs.json._
+import play.api.libs.json.*
 
 enum ScanStatus {
   case READY, FAILED

--- a/app/models/Sort.scala
+++ b/app/models/Sort.scala
@@ -16,7 +16,7 @@
 
 package models
 
-import cats.syntax.either._
+import cats.syntax.either.*
 import models.SortDirection.{ASCENDING, DESCENDING, SortDirection}
 import models.SortField.{CREATED_DATE, SortField}
 import play.api.mvc.QueryStringBindable

--- a/app/models/UserAnswers.scala
+++ b/app/models/UserAnswers.scala
@@ -17,8 +17,8 @@
 package models
 
 import models.cache.CacheMap
-import pages._
-import play.api.libs.json._
+import pages.*
+import play.api.libs.json.*
 
 case class UserAnswers(cacheMap: CacheMap) extends Enumerable.Implicits {
 

--- a/app/navigation/Journey.scala
+++ b/app/navigation/Journey.scala
@@ -16,7 +16,7 @@
 
 package navigation
 
-import pages._
+import pages.*
 
 sealed abstract class Journey extends Product with Serializable {
   def questionPage: QuestionPage[Boolean]

--- a/app/navigation/Navigator.scala
+++ b/app/navigation/Navigator.scala
@@ -18,7 +18,7 @@ package navigation
 
 import config.FrontendAppConfig
 import controllers.routes
-import models._
+import models.*
 import pages._
 import play.api.mvc.Call
 

--- a/app/service/CasesService.scala
+++ b/app/service/CasesService.scala
@@ -17,7 +17,7 @@
 package service
 
 import connectors.{BindingTariffClassificationConnector, EmailConnector}
-import models._
+import models.*
 import models.requests.NewEventRequest
 import play.api.Logging
 import uk.gov.hmrc.http.HeaderCarrier

--- a/app/service/FileService.scala
+++ b/app/service/FileService.scala
@@ -18,7 +18,7 @@ package service
 
 import config.FrontendAppConfig
 import connectors.BindingTariffFilestoreConnector
-import models._
+import models.*
 import models.requests.FileStoreInitiateRequest
 import models.response.{FileStoreInitiateResponse, FilestoreResponse}
 import org.apache.pekko.stream.scaladsl.Source

--- a/app/service/UserAnswerDeletionService.scala
+++ b/app/service/UserAnswerDeletionService.scala
@@ -17,7 +17,7 @@
 package service
 
 import models.UserAnswers
-import pages._
+import pages.*
 
 class UserAnswerDeletionService {
 

--- a/app/utils/CheckYourAnswersHelper.scala
+++ b/app/utils/CheckYourAnswersHelper.scala
@@ -19,7 +19,7 @@ package utils
 import controllers.routes
 import models.requests.DataRequest
 import models.{CheckMode, Country, FileAttachment, UserAnswers}
-import pages._
+import pages.*
 import play.api.i18n.Messages
 import viewmodels.AnswerRow
 import play.api.Logging

--- a/app/utils/JsonFormatters.scala
+++ b/app/utils/JsonFormatters.scala
@@ -17,9 +17,9 @@
 package utils
 
 import audit.CaseAuditPayload
-import models._
+import models.*
 import models.requests.NewEventRequest
-import play.api.libs.json._
+import play.api.libs.json.*
 import viewmodels.{FileView, PdfViewModel}
 
 import scala.language.implicitConversions

--- a/app/viewmodels/Dashboard.scala
+++ b/app/viewmodels/Dashboard.scala
@@ -19,9 +19,9 @@ package viewmodels
 import controllers.routes
 import models.SortDirection.SortDirection
 import models.SortField.{CREATED_DATE, SortField}
-import models._
+import models.*
 import play.api.mvc.Request
-import viewmodels.Dashboard._
+import viewmodels.Dashboard.*
 
 import java.net.URLEncoder.encode
 

--- a/app/views/supportingMaterialFileList.scala.html
+++ b/app/views/supportingMaterialFileList.scala.html
@@ -57,6 +57,8 @@
             )
         } else {
 
+            @components.heading(headingMessage, captionMsg = Some(messages("supportingMaterialFileList.caption")))
+
             @indicationsContent
 
             @components.input_yes_no(

--- a/app/views/uploadSupportingMaterialMultiple.scala.html
+++ b/app/views/uploadSupportingMaterialMultiple.scala.html
@@ -84,10 +84,7 @@
                 .getElementById("file")
                 .addEventListener("change", onFileSelected(id, targetURL, csrfToken));
 
-            window.addEventListener("pageshow", function(event) {
-                const files = document.querySelectorAll('input[type="file"]');
-                files.forEach(input => input.value = '');
-            });
+
         </script>
     }
 }

--- a/app/views/uploadSupportingMaterialMultiple.scala.html
+++ b/app/views/uploadSupportingMaterialMultiple.scala.html
@@ -83,6 +83,11 @@
             document
                 .getElementById("file")
                 .addEventListener("change", onFileSelected(id, targetURL, csrfToken));
+
+            window.addEventListener("pageshow", function(event) {
+                const files = document.querySelectorAll('input[type="file"]');
+                files.forEach(input => input.value = '');
+            });
         </script>
     }
 }

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -13,7 +13,7 @@ object AppDependencies {
     "commons-codec"          % "commons-codec"              % "1.18.0",
     "org.typelevel"         %% "cats-core"                  % "2.13.0",
     "commons-io"             % "commons-io"                 % "2.19.0",
-    "org.apache.xmlgraphics" % "fop"                        % "2.11",
+    "org.apache.xmlgraphics" % "fop"                        % "2.10",
     "net.sf.saxon"           % "Saxon-HE"                   % "12.7"
   )
 

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -3,11 +3,11 @@ import sbt.*
 object AppDependencies {
 
   private val hmrcMongoPlayVersion = "2.6.0"
-  private val bootstrapPlayVersion = "9.12.0"
+  private val bootstrapPlayVersion = "9.13.0"
 
   private lazy val compile: Seq[ModuleID] = Seq(
     "commons-validator"      % "commons-validator"          % "1.9.0",
-    "uk.gov.hmrc"           %% "play-frontend-hmrc-play-30" % "12.1.0",
+    "uk.gov.hmrc"           %% "play-frontend-hmrc-play-30" % "12.5.0",
     "uk.gov.hmrc"           %% "bootstrap-frontend-play-30" % bootstrapPlayVersion,
     "uk.gov.hmrc.mongo"     %% "hmrc-mongo-play-30"         % hmrcMongoPlayVersion,
     "commons-codec"          % "commons-codec"              % "1.18.0",

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -3,18 +3,18 @@ import sbt.*
 object AppDependencies {
 
   private val hmrcMongoPlayVersion = "2.6.0"
-  private val bootstrapPlayVersion = "9.11.0"
+  private val bootstrapPlayVersion = "9.12.0"
 
   private lazy val compile: Seq[ModuleID] = Seq(
     "commons-validator"      % "commons-validator"          % "1.9.0",
-    "uk.gov.hmrc"           %% "play-frontend-hmrc-play-30" % "12.0.0",
+    "uk.gov.hmrc"           %% "play-frontend-hmrc-play-30" % "12.1.0",
     "uk.gov.hmrc"           %% "bootstrap-frontend-play-30" % bootstrapPlayVersion,
     "uk.gov.hmrc.mongo"     %% "hmrc-mongo-play-30"         % hmrcMongoPlayVersion,
     "commons-codec"          % "commons-codec"              % "1.18.0",
     "org.typelevel"         %% "cats-core"                  % "2.13.0",
     "commons-io"             % "commons-io"                 % "2.19.0",
-    "org.apache.xmlgraphics" % "fop"                        % "2.10",
-    "net.sf.saxon"           % "Saxon-HE"                   % "12.6"
+    "org.apache.xmlgraphics" % "fop"                        % "2.11",
+    "net.sf.saxon"           % "Saxon-HE"                   % "12.7"
   )
 
   private lazy val test: Seq[ModuleID] = Seq(

--- a/test/controllers/SupportingMaterialFileListControllerSpec.scala
+++ b/test/controllers/SupportingMaterialFileListControllerSpec.scala
@@ -16,17 +16,17 @@
 
 package controllers
 
-import controllers.actions._
+import controllers.actions.*
 import controllers.behaviours.YesNoCachingControllerBehaviours
 import forms.SupportingMaterialFileListFormProvider
 import models.cache.CacheMap
-import models.{FileAttachment, NormalMode}
+import models.{FileAttachment, NormalMode, UserAnswers}
 import navigation.FakeNavigator
-import pages.{AddSupportingDocumentsPage, ProvideGoodsNamePage, UploadSupportingMaterialMultiplePage}
+import pages.{AddSupportingDocumentsPage, ProvideGoodsNamePage, QuestionPage, UploadSupportingMaterialMultiplePage}
 import play.api.data.Form
-import play.api.libs.json.{JsArray, JsBoolean, JsString, Json}
+import play.api.libs.json.{Format, JsArray, JsBoolean, JsString, JsValue, Json}
 import play.api.mvc.{Call, Request}
-import play.api.test.Helpers._
+import play.api.test.Helpers.*
 import service.FakeDataCacheService
 import views.html.supportingMaterialFileList
 

--- a/test/service/MongoCacheServiceSpec.scala
+++ b/test/service/MongoCacheServiceSpec.scala
@@ -19,6 +19,7 @@ package service
 import connectors.ConnectorTest
 import generators.Generators
 import models.cache.CacheMap
+import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.{any, refEq}
 import org.mockito.Mockito.{mock, verify, when}
 import org.scalacheck.Arbitrary.arbitrary
@@ -62,26 +63,24 @@ class MongoCacheServiceSpec
 
   }
 
-//  ".keepAlive" must {
-//
-//    "keep the cache map for the length of 2 hours in the Mongo repository" in {
-//
-//      when(repository.extendTime(any[CacheMap])).thenReturn(Future.successful(true))
-//
-//      val mongoCacheService: MongoCacheService = new MongoCacheService(repository, metrics)
-//
-//      forAll(arbitrary[CacheMap]) { cacheMap =>
-//        val result = mongoCacheService.keepAlive(cacheMap)
-//
-//        whenReady(result) { savedCacheMap =>
-//          println(savedCacheMap)
-//          savedCacheMap shouldEqual cacheMap
-//          verify(repository).extendTime(cacheMap)
-//        }
-//
-//      }
-//    }
-//  }
+  ".keepAlive" must {
+
+    "keep the cache map for the length of 2 hours in the Mongo repository" in {
+
+      when(repository.extendTime(any[CacheMap], ArgumentMatchers.eq(7200L))).thenReturn(Future.successful(true))
+
+      val mongoCacheService: MongoCacheService = new MongoCacheService(repository, metrics)
+
+      forAll(arbitrary[CacheMap]) { cacheMap =>
+        val result = mongoCacheService.keepAlive(cacheMap, 7200L)
+
+        whenReady(result) { savedCacheMap =>
+          savedCacheMap shouldEqual cacheMap
+          verify(repository).extendTime(cacheMap, 7200L)
+        }
+      }
+    }
+  }
 
   ".remove" must {
 

--- a/test/views/SupportingMaterialFileListViewSpec.scala
+++ b/test/views/SupportingMaterialFileListViewSpec.scala
@@ -43,10 +43,10 @@ class SupportingMaterialFileListViewSpec extends YesNoViewBehaviours {
     behave like pageWithBackLink(createView)
 
     "show the expected heading when no files have been uploaded" in
-      assertHeading(0)
+      assertHeading(1)
 
     "show the expected heading when 1 file has been uploaded" in
-      assertHeading(1)
+      assertHeading(2)
 
     "show the expected heading when multiple file have been uploaded" in
       assertHeading(2)


### PR DESCRIPTION
1. uncommented code 
2. added javascript to reset file picker as the file does not persist once removed